### PR TITLE
temp: 一時的にrender-build.sh の内容を書き換え (本番環境のdb:migrate:resetが完了したら絶対戻す)

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,4 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate
+bundle exec rails db:migrate:reset


### PR DESCRIPTION
過去に db:migrate:reset を使ってマイグレーション対応していた影響で、本番環境ではマイグレーションが正しく反映されていない状態でした。
今後は db:migrate による差分適用に切り替える予定です。
今回は Render Free プランの制約により shell が使えないため、一時的に render-build.sh に db:migrate:reset を仕込み、強制的に本番DBを再構築して対応します。