### PR TITLE
ノード編集画面のテクニック＋展開先テクニック同時更新

### DIFF
--- a/app/forms/node_edit_form.rb
+++ b/app/forms/node_edit_form.rb
@@ -1,0 +1,108 @@
+class NodeEditForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  # ---- 属性 ----
+  # ノードとユーザーはコンストラクタで受け取り、操作対象を決める
+  attr_reader :node, :current_user
+
+  # Techniqueの編集項目
+  attribute :name_ja, :string
+  attribute :note, :string
+  attribute :category, :string
+
+  # UIから受け取る情報
+  attribute :children, default: [] # ["1", "2", "new: XX"] のような配列
+  attribute :chart_id, :integer    # リダイレクト先の判定に使う
+
+  validates :name_ja, presence: true
+
+  # ====== 初期化 ======
+  def initialize(node:, current_user:, **attrs)
+    @node = node
+    @current_user = current_user
+    super(attrs)
+
+    # 初期表示用にTechniqueから値を埋めておく（attrs があれば優先）
+    self.name_ja ||= technique.name_ja
+    self.note    ||= technique.note
+    self.category ||= technique.category
+    self.children = normalize_children(self.children.presence || node.children.pluck(:technique_id).map!(&:to_s))
+    self.chart_id ||= node.chart_id
+  end
+
+  # 画面→保存 本体
+  def save
+    ActiveRecord::Base.transaction do
+      # 1) Techniqueの更新
+      technique.assign_attributes(
+        name_ja: name_ja,
+        note: note,
+        category: category
+      )
+      unless technique.save
+        propagate_errors_from(technique)
+        raise ActiveRecord::Rollback
+      end
+
+      # 2) 子ノード（展開先）の更新
+      selected_ids = resolve_selected_technique_ids(children)
+      current_ids = node.children.pluck(:technique_id)
+
+      ids_to_add    = selected_ids - current_ids
+      ids_to_remove = current_ids - selected_ids
+
+      # 追加
+      ids_to_add.each do |tid|
+        node.children.create!(chart: node.chart, technique_id: tid)
+      end
+      # 削除
+      node.children.where(technique_id: ids_to_remove).destroy_all
+    end
+
+    errors.empty?
+  rescue ActiveRecord::RecordInvalid => e
+    errors.add(:base, e.message)
+    false
+  rescue StandardError => e
+    errors.add(:base, "更新に失敗しました: #{e.message}")
+    false
+  end
+
+  # 表示用：セレクトの選択済み値を返す
+  def selected_children_ids
+    node.children.pluck(:technique_id).map!(&:to_s)
+  end
+
+  private
+
+  def technique
+    @technique ||= node.technique
+  end
+
+  def normalize_children(arr)
+    Array(arr).map(&:to_s) # nil安全・文字列化
+  end
+
+  # "new: ○○" は作成・既存IDはそのまま採用
+  def resolve_selected_technique_ids(raw_children)
+    new_names, existing_ids = [], []
+    normalize_children(raw_children).each do |val|
+      if val.start_with?("new: ")
+        new_names << val.sub(/^new: /, "")
+      elsif val.present?
+        existing_ids << val.to_i
+      end
+    end
+    new_ids = new_names.map do |name|
+      current_user.techniques.find_or_create_by!(name_ja: name, name_en: name).id
+    end
+    (existing_ids.compact + new_ids).uniq
+  end
+
+  def propagate_errors_from(record)
+    record.errors.each do |error|
+      errors.add(error.attribute, error.message)
+    end
+  end
+end

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -8,7 +8,7 @@
         <p>本日も練習で学んだことを記録しましょう。</p>
         <p>本アプリの使い方については、以下のステップガイドをご参照ください。</p>
         <div class="flex justify-center">
-        <button data-action="click->step-guide#startMenuGuide" class="btn btn-primary btn-wide my-10">ステップガイドを始める</button>
+        <button data-action="click->step-guide#startMenuGuide" class="btn btn-primary btn-wide btn-lg my-10">ステップガイドを始める</button>
         </div>
       </div>
     </div>

--- a/app/views/mypage/nodes/edit.html.erb
+++ b/app/views/mypage/nodes/edit.html.erb
@@ -10,66 +10,53 @@
 
   <div id="step0n" data-intro-text="ここでは、ノード編集画面について説明します。" class="hidden"></div>
 
-  <%= form_with model: @technique,
-      url: mypage_technique_path(@technique),
+  <%= form_with model: @form,
+      url: mypage_node_path(@node),
       method: :patch,
       id: "step1n",
       data: { title_text: "テクニック更新", 
               intro_text: "このフィールドから、テクニックの情報を更新することができます。<br><br>この画面で更新された情報は、<a class='underline font-bold' href='#{mypage_techniques_path}'>Technique</a> メニューの内容にも反映されます。"
             } do |f|
   %>
-    <!-- リダイレクト先指定のため、techniques_controller へ chart_id を渡す必要がある -->
-    <!-- TODO: このあたりの処理は Formオブジェクト に移したい-->
-    <%= hidden_field_tag :chart_id, @chart.id %>
     <div class="flex flex-col items-center">
       <%= render 'mypage/techniques/form_core', f: f %>
-      <%= f.submit "保存", class: "btn btn-primary w-4/5", data: { turbo_frame: "_top" } %>
+
+      <div class="divider my-8"></div>
+
+      <div
+        id="step2n" 
+        class="space-y-2 w-4/5 mx-auto"
+        data-title-text="展開先テクニック更新"
+        data-intro-text="このテクニックから展開される技を編集することができます。<br><br>ここで展開先として選択されたテクニックは、このテクニックの右側に接続される形でチャート上に描写されます。"
+      >
+        <%= f.label "children", "展開先テクニック" %>
+        <%= f.select "children",
+            grouped_options_for_select(@grouped, @selected_ids),
+            {},
+            id: "children_nodes",
+            multiple: true,
+            placeholder: "テクニックを検索",
+            data: { controller: "tom-select" }
+        %>
+      </div>
     </div>
-  <% end %>
 
-  <div class="divider my-8"></div>
-
-  <%= form_with model: @node,
-      url: mypage_node_path(@node),
-      method: :patch,
-      id: "step2n",
-      class: "space-y-2 w-4/5 mx-auto", 
-      data: { title_text: "展開先テクニック更新",
-              intro_text: "このテクニックから展開される技を編集することができます。<br><br>ここで展開先として選択されたテクニックは、このテクニックの右側に接続される形でチャート上に描写されます。"
-            } do |ff|
-  %>
-
-    <%= label_tag "children_nodes", "展開先テクニック" %>
-    <%= select_tag "node[children][]",
-          grouped_options_for_select(@grouped, @selected_ids),
-          id: "children_nodes",
-          multiple: true,
-          placeholder: "テクニックを検索",
-          data: { controller: "tom-select" }
-    %>
-
-    <div class="flex justify-center">
-      <%= ff.submit "更新", class: "btn btn-secondary btn-wide", data: { turbo_frame: "_top" } %>
-    </div>
-  <% end %>
-
-  <div class="divider my-8"></div>
-
-  <div class="flex justify-center">
-    <!-- button_to ではフォームが生成されるので、data-turbo-method ではなく、method で delete を指定する -->
-    <!-- link_to はaタグが生成されるので、data-turbo-method: :delete を使うことで擬似的に削除ボタンを作ることができる -->
-    <%= button_to "このノードをチャートから削除", 
+    <div class="flex flex-col w-2/5 mt-10 gap-2 mx-auto">
+      <%= f.submit "更新", class: "btn btn-primary", data: { turbo_frame: "_top" } %>
+      <%= link_to "このノードをチャートから削除", 
         mypage_node_path(@node),
-        method: :delete, 
         id: "step3n",
-        class: "btn btn-error btn-wide",
-        data: { turbo_confirm: "本当に削除しますか？",
+        class: "btn btn-error",
+        data: { 
+                turbo_method: :delete,
+                turbo_confirm: "本当に削除しますか？",
                 turbo_frame: "_top",
                 title_text: "ノード削除",
                 intro_text: "こちらからノードを削除することができます。<br><br>ノードを削除すると、展開先テクニックとして接続されていたノードもすべて削除されますので、ご注意ください。"
               }
-    %>
-  </div>
+      %>
+    </div>
+  <% end %>
 
   <div id="step4n" data-title-text="ガイドが完了しました！お疲れ様です！" data-intro-text="ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋" class="hidden"></div>
 <% end %>

--- a/app/views/mypage/techniques/_form_core.html.erb
+++ b/app/views/mypage/techniques/_form_core.html.erb
@@ -7,7 +7,8 @@
       <%= f.text_field :name_ja, class: "input input-bordered w-full" %>
   
       <%= f.label :note, "ノート" %>
-      <%= f.text_area :note, class: "textarea textarea-bordered w-full" %>
+      <%= f.text_area :note, class: "textarea textarea-bordered w-full field-sizing-content
+" %>
   
       <%= f.label :category, "カテゴリー" %>
       <%= f.select :category, Technique.categories.keys.map { |c| [c.humanize, c] }, { include_blank: "未分類" }, class: "select select-bordered w-full" %>

--- a/app/views/mypage/techniques/index.html.erb
+++ b/app/views/mypage/techniques/index.html.erb
@@ -11,16 +11,16 @@
   
   <div id="step0" class="hidden" data-intro-text="こちらは、柔術のテクニックが一覧として並んでいる画面です。"></div>
 
-  <div class="flex flex-col gap-2 items-center">
+  <div class="flex flex-col items-center justify-center gap-3">
     <%= link_to "新規作成" , new_mypage_technique_path, class: "btn btn-primary btn-wide", id: "step1", data: { title_text: "新規作成", intro_text: "一覧にないテクニックは、こちらのボタンから新規作成することができます。" } %>
-    <%= search_form_for @q, url: mypage_techniques_path, id: "step2",
+    <%= search_form_for @q, url: mypage_techniques_path, id: "step2", class: "w-80",
           data: { turbo_frame: "technique-list",
                   controller: "instant-search",
                   action: "input->instant-search#autosubmit",
                   title_text: "検索",
                   intro_text: "一覧にあるテクニックは、ここから検索して表示を絞り込むことができます。"
           } do |f| %>
-      <label class="input w-80">
+      <label class="input">
         <svg class="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <g
             stroke-linejoin="round"
@@ -52,7 +52,7 @@
   </div>
 
   <%= turbo_frame_tag "technique-list" do %>
-    <div class="space-y-2 w-80 mx-auto">
+    <div class="space-y-2 max-w-screen-2xl mx-auto">
       <% if @techniques.present? %>
         <% @techniques.each do |technique| %>
           <div class="collapse collapse-arrow bg-base-200 shadow-md">
@@ -81,11 +81,9 @@
               <span class="text-lg font-medium" ><%= technique.name_ja %></span>
             </div>
             <div class="collapse-content flex flex-col items-center">
-              <%= form_with model: technique, url: mypage_technique_path(technique), method: :patch do |f| %>
+              <%= form_with model: technique, url: mypage_technique_path(technique), method: :patch, class: "w-full" do |f| %>
                 <%= render 'shared/error_messages', object: technique %>
-                <div class="w-72 mx-auto m-4">
-                  <%= render 'form_core', f: f %>
-                </div>
+                <%= render 'form_core', f: f %>
                 <div class="flex flex-col items-center space-y-4 mt-10">
                   <!-- turbo_frame: "_top" を指定してページ全体をリロードしないと、フラッシュメッセージが表示されない。-->
                   <%= f.submit "保存", class: "btn btn-primary btn-wide", data: { turbo_frame: "_top" } %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -92,7 +92,7 @@
 <div class="m-4 mb-8">
   当サービスは、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。Googleアナリティクスについて、詳しくは以下からご確認ください。
   <div class="ml-4">
-    <%= link_to "https://marketingplatform.google.com/about/analytics/terms/jp/", "https://marketingplatform.google.com/about/analytics/terms/jp/", class: "link link-hover" %>
+    <%= link_to "https://marketingplatform.google.com/about/analytics/terms/jp/", "https://marketingplatform.google.com/about/analytics/terms/jp/", class: "link link-hover break-all" %>
   </div>
 </div>
 
@@ -111,7 +111,7 @@
     お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、以下のメールアドレスにご連絡ください。
   </div>
   <div class="ml-4">
-    <%= link_to "bjjflowtracker@gmail.com", "mailto:bjjflowtracker@gmail.com", class: "link link-hover" %>
+    <%= link_to "bjjflowtracker@gmail.com", "mailto:bjjflowtracker@gmail.com", class: "link link-hover break-all" %>
   </div>
 
   <div>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activemodel:
+    attributes:
+      node_edit_form:
+        name_ja: テクニック名
+        name_en: テクニック名(英語)
+        category: カテゴリー
+        note: ノート
+        children: 展開先テクニック
+

--- a/db/changelog.yml
+++ b/db/changelog.yml
@@ -8,6 +8,10 @@
 #  other: "badge"
 #  }.freeze
 
+- date: "2025-09-04"
+  kind: changed
+  title: UI改善
+  body: ノード編集画面にて、「テクニックの情報」と「展開先テクニック」を同時に更新できるようにしました。
 - date: "2025-09-03"
   kind: fixed
   title: パフォーマンス改善


### PR DESCRIPTION
## close #122 
- ノード編集画面では、テクニック情報 `@technique` と 展開先テクニック `@node` は同時に更新ができなかった（更新ボタンが別になっていた）ため、これを同時更新できるようにした（更新ボタンを一つにした）。
## その他、軽微な修正
- プライバシーポリシーのリンクの表示を修正（モバイル画面でもリンクが飛び出ない）
- テクニックノートのtextareaがコンテンツ量に合わせて伸長するようにした