### PR TITLE
ルートノード作成画面にて、開始点テクニック選択の描写範囲が狭くなっている問題を解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ group :development do
 
   # Simple Coverage
   gem "simplecov"
+
+  # to detect unused i18n key
+  gem "i18n-tasks"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,8 +144,21 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    highline (3.1.2)
+      reline
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.15)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
+      terminal-table (>= 1.5.1)
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -394,6 +407,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.4.0)
     timeout (0.4.3)
     turbo-rails (2.0.16)
@@ -449,6 +464,7 @@ DEPENDENCIES
   devise-i18n
   factory_bot_rails
   faker
+  i18n-tasks
   jbuilder
   jsbundling-rails
   meta-tags

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -7,6 +7,8 @@ class Mypage::NodesController < ApplicationController
     @grouped = @candidate_techniques
         .group_by { |t| t.category ? t.category.humanize : "未分類" }
         .transform_values { |arr| arr.map { |t| [ t.name_ja, t.id ] } }
+
+    render :new, formats: :turbo_stream
   end
 
   def create
@@ -74,6 +76,8 @@ class Mypage::NodesController < ApplicationController
       (@candidate_techniques + @node.children.includes(:technique).map(&:technique))
         .group_by { |t| t.category ? t.category.humanize : "未分類" }
         .transform_values { |arr| arr.map { |t| [ t.name_ja, t.id ] } }
+
+    render :edit, formats: :turbo_stream
   end
 
   def update

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -15,7 +15,7 @@ class Mypage::NodesController < ApplicationController
     begin
       ActiveRecord::Base.transaction do
         roots = Array(create_params[:roots])
-        raise ArgumentError, "フローの開始点を1つ以上選択してください" if roots.empty?
+        raise ArgumentError, t("defaults.flash_messages.multiple_select", item: t("terms.root_nodes")) if roots.empty?
 
         new_names = []
         existing_ids = []
@@ -41,7 +41,7 @@ class Mypage::NodesController < ApplicationController
         end
       end
 
-      redirect_to mypage_chart_path(@chart), notice: "フローの開始点を作成しました"
+      redirect_to mypage_chart_path(@chart), notice: t("defaults.flash_messages.created", item: t("terms.root_nodes"))
 
     rescue ArgumentError => e
       flash[:alert] = e.message
@@ -50,7 +50,8 @@ class Mypage::NodesController < ApplicationController
       flash[:alert] = e.message
       redirect_to mypage_chart_path(@chart)
     rescue StandardError => e
-      flash[:alert] = "フローの開始点を作成できませんでした"
+      flash[:alert] = redirect_to mypage_chart_path(@chart), notice: t("defaults.flash_messages.note_created", item: t("terms.root_nodes"))
+
       redirect_to mypage_chart_path(@chart)
     end
   end
@@ -88,9 +89,9 @@ class Mypage::NodesController < ApplicationController
     chart = @node.chart
 
     if @form.save
-      redirect_to mypage_chart_path(chart), notice: "展開先テクニックを更新しました", status: :see_other
+      redirect_to mypage_chart_path(chart), notice: t("defaults.flash_messages.updated", item: Node.model_name.human), status: :see_other
     else
-      flash[:alert] = "保存できませんでした"
+      flash[:alert] = t("defaults.flash_messages.not_updated", item: Node.model_name.human)
       flash[:errors] = @form.errors.full_messages
       # status: :unprocessable_entity(422) だと フルページ更新できない
       redirect_to mypage_chart_path(chart), status: :see_other
@@ -101,7 +102,7 @@ class Mypage::NodesController < ApplicationController
     node = current_user.nodes.find(params[:id])
     chart = node.chart
     node.destroy!
-    redirect_to mypage_chart_path(chart), notice: "ノードを削除しました", status: :see_other
+    redirect_to mypage_chart_path(chart), notice: t("defaults.flash_messages.deleted", item: Node.model_name.human), status: :see_other
   end
 
   private

--- a/app/controllers/mypage/techniques_controller.rb
+++ b/app/controllers/mypage/techniques_controller.rb
@@ -15,9 +15,9 @@ class Mypage::TechniquesController < ApplicationController
   def create
     @technique = current_user.techniques.build(technique_params)
     if @technique.save
-      redirect_to mypage_techniques_path, notice: "保存しました"
+      redirect_to mypage_techniques_path, notice: t("defaults.flash_messages.created", item: Technique.model_name.human)
     else
-      flash.now[:alert] = "保存できませんでした"
+      flash.now[:alert] = t("defaults.flash_messages.not_created", item: Technique.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -35,9 +35,9 @@ class Mypage::TechniquesController < ApplicationController
 
     if @technique.update(technique_params)
       # チャート画面上からテクニックを更新した場合、chart_idがparamsに含まれる。
-      redirect_to mypage_techniques_path, notice: "保存しました", status: :see_other
+      redirect_to mypage_techniques_path, notice: t("defaults.flash_messages.updated", item: Technique.model_name.human), status: :see_other
     else
-      flash[:alert] = "保存できませんでした"
+      flash[:alert] = t("defaults.flash_messages.not_updated", item: Technique.model_name.human)
 
       # turbo_frame内で render 'shared/error_message' しても描写されないので、flash[:errors]経由でエラーメッセージ詳細を描写する。
       flash[:errors] = @technique.errors.full_messages
@@ -48,7 +48,7 @@ class Mypage::TechniquesController < ApplicationController
   def destroy
     technique = Technique.find(params[:id])
     technique.destroy!
-    redirect_to mypage_techniques_path, notice: "削除しました"
+    redirect_to mypage_techniques_path, notice: t("defaults.flash_messages.deleted", item: Technique.model_name.human)
   end
 
   private

--- a/app/views/mypage/charts/show.html.erb
+++ b/app/views/mypage/charts/show.html.erb
@@ -59,16 +59,12 @@
         </button> をクリックしてください！"
     >
 
-      <div class="flex flex-end justify-between p-3">
-        <div class="flex items-center mb-4">
-          <h2 class="text-lg font-bold mr-2">ノード編集</h2>
-          <div class="tooltip tooltip-right" data-tip="ステップガイドを開始" data-action="click->step-guide#startNodeGuide">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
-            </svg>
-          </div>
-        </div>
-        <!-- ✕ボタン（クリックで閉じる） -->
+      <div class="flex p-3 justify-between items-center">
+        <%= turbo_frame_tag "node-drawer-header" do %>
+          <!-- empty until the node clicked -->
+        <% end %>
+
+        <!-- ✕ボタン（クリックで閉じる）。newとeditで共通するパーツ。 -->
         <label class="btn btn-sm btn-circle btn-ghost " data-action="click->chart#closeDrawer">✕</label>
       </div>
 

--- a/app/views/mypage/charts/show.html.erb
+++ b/app/views/mypage/charts/show.html.erb
@@ -62,7 +62,7 @@
       <div class="flex flex-end justify-between p-3">
         <div class="flex items-center mb-4">
           <h2 class="text-lg font-bold mr-2">ノード編集</h2>
-          <div class="tooltip tooltip-bottom" data-tip="ステップガイドを開始するにはここをクリック" data-action="click->step-guide#startNodeGuide">
+          <div class="tooltip tooltip-right" data-tip="ステップガイドを開始" data-action="click->step-guide#startNodeGuide">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
             </svg>

--- a/app/views/mypage/charts/show.html.erb
+++ b/app/views/mypage/charts/show.html.erb
@@ -47,7 +47,7 @@
     <!-- z-2を指定しないと、「新しいフローを作る」ボタンの下にドロワーが潜って表示されてしまう -->
     <aside
       id="step3"
-      class="flex flex-col bg-base-200 w-full sm:w-[32rem] max-w-[90vw] h-full p-4 z-2"
+      class="flex flex-col bg-base-200 w-full sm:w-[32rem] max-w-[90vw] h-full overflow-y-auto p-4 z-2"
       role="dialog"
       aria-modal="true"
       data-title-text="ノード編集"
@@ -72,7 +72,7 @@
         <label class="btn btn-sm btn-circle btn-ghost " data-action="click->chart#closeDrawer">✕</label>
       </div>
 
-      <%= turbo_frame_tag "node-drawer", class: "overflow-y-auto", data: { chart_target: "drawer" } do %>
+      <%= turbo_frame_tag "node-drawer", data: { chart_target: "drawer" } do %>
         <!-- empty until the node clicked -->
       <% end %>
     </aside>

--- a/app/views/mypage/nodes/_drawer_header.html.erb
+++ b/app/views/mypage/nodes/_drawer_header.html.erb
@@ -1,0 +1,16 @@
+<!-- ノード編集画面ならtrue, フローの開始点作成画面ならfalse -->
+<!-- パーシャル呼び出し元から、editing: true/false を受け取る。デフォルトはfalse -->
+<% editing = local_assigns.fetch(:editing, false) %>
+
+<% if editing %>
+  <div class="flex items-center m-4">
+    <h2 class="text-lg font-bold mr-2">ノード編集</h2>
+    <div class="tooltip tooltip-right" data-tip="ステップガイドを開始" data-action="click->step-guide#startNodeGuide">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
+      </svg>
+    </div>
+  </div>
+<% else %>
+  <h2 class="text-lg font-bold mr-2">フローの開始点を新規作成</h2>
+<% end %>

--- a/app/views/mypage/nodes/edit.turbo_stream.erb
+++ b/app/views/mypage/nodes/edit.turbo_stream.erb
@@ -1,5 +1,8 @@
-<%= turbo_frame_tag "node-drawer" do %>
+<%= turbo_stream.update "node-drawer-header" do %>
+  <%= render "drawer_header", editing: true %>
+<% end %>
 
+<%= turbo_stream.update "node-drawer" do %>
   <div id="step0n" data-intro-text="ここでは、ノード編集画面について説明します。" class="hidden"></div>
 
   <%= form_with model: @form, url: mypage_node_path(@node), method: :patch do |f| %>
@@ -52,5 +55,10 @@
     </div>
   <% end %>
 
-  <div id="step4n" data-title-text="ガイドが完了しました！お疲れ様です！" data-intro-text="ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋" class="hidden"></div>
+  <div
+  id="step4n"
+  data-title-text="ガイドが完了しました！お疲れ様です！"
+  data-intro-text="ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋" class="hidden"
+  >
+  </div>
 <% end %>

--- a/app/views/mypage/nodes/new.turbo_stream.erb
+++ b/app/views/mypage/nodes/new.turbo_stream.erb
@@ -1,6 +1,8 @@
-<%= turbo_frame_tag "node-drawer" do %>
-  <h2 class="text-lg font-bold mb-4">フローの開始点を新規作成</h2>
+<%= turbo_stream.update "node-drawer-header" do %>
+  <%= render "drawer_header", editing: false %>
+<% end %>
 
+<%= turbo_stream.update "node-drawer" do %>
   <%= form_with url: mypage_chart_nodes_path(@chart), method: :post, class: "space-y-2 mt-10 w-4/5 mx-auto" do |f| %>
     <div class="flex items-center space-x-2">
       <%= label_tag "root_nodes", "開始点テクニック" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  terms:
+    root_nodes: フローの開始点
+    children_nodes: 展開先テクニック
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+  defaults:
+    flash_messages:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成できませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新できませんでした"
+      deleted: "%{item}を削除しました"
+      multiple_select: "%{item}を1つ以上選択してください"
+  header:
+    login: ログイン
+    logout: ログアウト

--- a/db/changelog.yml
+++ b/db/changelog.yml
@@ -8,6 +8,10 @@
 #  other: "badge"
 #  }.freeze
 
+- date: "2025-09-08"
+  kind: fixed
+  title: バグ修正
+  body: 新しいフロー作成画面にて、開始点テクニック選択肢の描写範囲が狭い問題を解消しました。
 - date: "2025-09-04"
   kind: changed
   title: UI改善


### PR DESCRIPTION
## 改修前
[![Image from Gyazo](https://i.gyazo.com/e775a1e0ba80d4fd5f92027218dfd610.png)](https://gyazo.com/e775a1e0ba80d4fd5f92027218dfd610)

## 改修後
[![Image from Gyazo](https://i.gyazo.com/6f0e128583af9264914cd3f09ac5a73f.png)](https://gyazo.com/6f0e128583af9264914cd3f09ac5a73f)

## 経緯
#47 対応中に本バグを発見したため、同一ブランチ(develop)にて修正。

## 修正の要点
- turbo-frameタグにつけていた`class: overflow-y-auto` を、ドロワー全体(asideタグ)に移した。
- turbo streamsを利用し、ノード作成・編集画面の右上にあるクローズボタン(共通要素)以外の部分が差分更新されるようにした。