### PR TITLE
i18n対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,3 +97,6 @@ gem "ransack"
 
 # OGP
 gem "meta-tags"
+
+# i18n for the step guide
+gem "i18n-js"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    glob (0.4.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -148,6 +149,9 @@ GEM
       reline
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    i18n-js (4.2.3)
+      glob (>= 0.4.0)
+      i18n
     i18n-tasks (1.0.15)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
@@ -464,6 +468,7 @@ DEPENDENCIES
   devise-i18n
   factory_bot_rails
   faker
+  i18n-js
   i18n-tasks
   jbuilder
   jsbundling-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,6 @@ module ApplicationHelper
       reverse: true, # 「site | title」ではなく「title | site」の表記になる。
       charset: "utf-8",
       description: "#{base_title} では、ブラジリアン柔術の練習記録を整理し、試合やスパーの展開を可視化することができます。",
-      keywords: "柔術,ブラジリアン柔術,練習記録,運動,習慣化",
       canonical: request.base_url + request.path,
       separator: "|",
       og: {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 
+// PWA対応
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/service-worker.js')

--- a/app/javascript/controllers/step_guide_controller.js
+++ b/app/javascript/controllers/step_guide_controller.js
@@ -60,12 +60,6 @@ export default class extends Controller {
 	}
 
 	startTechniqueGuide() {
-		const step0 = document.querySelector("#step0")
-		const step1 = document.querySelector("#step1")
-		const step2 = document.querySelector("#step2")
-		const step3 = document.querySelector("#step3")
-		const step4 = document.querySelector("#step4")
-
 		const intro = introJs.tour().setOptions({
 			steps: [
 				{

--- a/app/javascript/controllers/step_guide_controller.js
+++ b/app/javascript/controllers/step_guide_controller.js
@@ -15,85 +15,78 @@ export default class extends Controller {
 		this.i18n = await ensureI18n();
 		this.scopeKey = this.scopeValue;
 		this.vars = {
-      techniques_path: this.techniquesPathValue || "",
-      charts_path: this.chartsPathValue || ""
-    }
-  }
+			techniques_path: this.techniquesPathValue || "",
+			charts_path: this.chartsPathValue || ""
+		}
+	}
 
 	// YAMLの scope オブジェクトを取得
-  scopeDict() {
-    const parts = this.scopeKey.split(".")
-    let current = this.i18n.translations?.[this.i18n.locale]
-    for (const p of parts) current = current?.[p]
-    return current || null
-  }
+	scopeDict() {
+		const parts = this.scopeKey.split(".")
+		let current = this.i18n.translations?.[this.i18n.locale]
+		for (const p of parts) current = current?.[p]
+		return current || null
+	}
 
-	  // 未翻訳かどうかの判定ヘルパ
-  tOrNull(key, vars = {}) {
-    const s = this.i18n.t(key, vars)
-    return (typeof s === "string" && /^\[missing /.test(s)) ? null : s
-  }
+	  // 未翻訳かどうかの判定ヘルパー
+	tOrNull(key, vars = {}) {
+		const s = this.i18n.t(key, vars)
+		return (typeof s === "string" && /^\[missing /.test(s)) ? null : s
+	}
 
-  // YAMLから step* を自動収集→並べ替え→steps配列へ
-  buildSteps() {
-    const dict = this.scopeDict()
-    if (!dict) return []
+	// YAMLから step* を自動収集→並べ替え→steps配列へ
+	buildSteps() {
+		const dict = this.scopeDict()
+		if (!dict) return []
+		
+		// stepキーを抽出して数値順に
+		const stepKeys = Object.keys(dict)
+			.filter(k => /^step\d+$/i.test(k))
+			.sort((a, b) => parseInt(a.replace(/\D/g, ""), 10) - parseInt(b.replace(/\D/g, ""), 10))
+		
+		const steps = []
+		for (const step of stepKeys) {
+			const base = `${this.scopeKey}.${step}`
+			const title = this.tOrNull(`${base}.title`)
+			const intro = this.tOrNull(`${base}.intro_html`, this.vars)
+			if (!title && !intro) continue  // どちらも無ければスキップ
+		
+			// selector も i18n から取得する（無ければ null）
+			const selector = this.tOrNull(`${base}.selector`) || null
+			const part = {}
+			if (title) part.title = title
+			if (intro) part.intro = intro
 
-    // stepキーを抽出して数値順に
-    const stepKeys = Object.keys(dict)
-      .filter(k => /^step\d+$/i.test(k))
-      .sort((a, b) => parseInt(a.replace(/\D/g, ""), 10) - parseInt(b.replace(/\D/g, ""), 10))
+			// ハイライトが当たった展開済みカードやドロワーが閉じられないようにする
+			const common = { ...part, disableInteraction: true }
 
-    const steps = []
-    for (const step of stepKeys) {
-      const base = `${this.scopeKey}.${step}`
-      const title = this.tOrNull(`${base}.title`)
-      const intro = this.tOrNull(`${base}.intro_html`, this.vars)
-      if (!title && !intro) continue  // どちらも無ければスキップ
+			if (selector) {
+				// セレクタ要素が存在しない場合は“全体ステップ”として落とす（スキップしたければ continue）
+				if (document.querySelector(selector)) {
+					steps.push({ element: selector, ...common })
+				} else {
+					steps.push(common)
+				}
+			} else {
+				steps.push(common)
+			}
+		}
+		return steps
+	}
 
-      // selector は“文言”ではないが i18n から取る（無ければ null）
-      const selector = this.tOrNull(`${base}.selector`) || null
-      const part = {}
-      if (title) part.title = title
-      if (intro) part.intro = intro
+	// どのガイドでも共通起動
+	start(onafterchange) {
+		const steps = this.buildSteps();
+		if (!steps.length) return;
 
-      if (selector) {
-        // セレクタ要素が存在しない場合は“全体ステップ”として落とす（スキップしたければ continue）
-        if (document.querySelector(selector)) {
-          steps.push({ element: selector, ...part })
-        } else {
-          steps.push(part)
-        }
-      } else {
-        steps.push(part)
-      }
-    }
-    return steps
-  }
+		const tour = introJs.tour().setOptions({
+			steps,
+			showBullets: false,
+			showProgress: true,
+		});
 
-  // どのガイドでも共通起動
-  start() {
-    const steps = this.buildSteps()
-    if (!steps.length) return
-    introJs().setOptions({ steps, showBullets: false, showProgress: true }).start()
-  }
-
-	stepPart(stepId) {
-		const k = `${this.scopeKey}.${stepId}`;
-		const vars = { techniques_path: this.techniques_path, charts_path: this.charts_path };
-
-		const titleStr = this.i18n.t(`${k}.title`);
-		const introStr = this.i18n.t(`${k}.intro_html`, vars);
-
-		// i18n-js は未定義キーだと "[missing ...]" を返す → それで判定
-		const isMissing = (s) => typeof s === "string" && /^\[missing /.test(s);
-
-		const part = {};
-		if (!isMissing(titleStr)) part.title = titleStr;
-		if (!isMissing(introStr)) part.intro = introStr;
-
-  	// どちらも無ければ null を返す。後に個々のstepguideにて　filter(Boolean)でnull削除。
-  	return Object.keys(part).length ? part : null;
+		if (onafterchange) tour.onAfterChange(onafterchange);
+		tour.start();
 	}
 
 	startDashboardGuide() {
@@ -101,145 +94,34 @@ export default class extends Controller {
 	}
 
 	startTechniqueGuide() {
-		const intro = introJs.tour().setOptions({
-			steps: [
-				{
-					intro: step0.dataset.introText
-				},
-				{
-					element: step1,
-					title: step1.dataset.titleText,
-					intro: step1.dataset.introText
-				},
-				{
-					element: step2,
-					title: step2.dataset.titleText,
-					intro: step2.dataset.introText
-				},
-				{
-					title: step3.dataset.titleText,
-					intro: step3.dataset.introText
-				},
-				{
-					element: document.querySelector(".drawer-side"),
-					title: step4.dataset.titleText,
-					intro: step4.dataset.introText,
-					// ハイライトが当たった展開済みカードが閉じられないようにする
-					disableInteraction: true
-				},
-				{
-					title: step5.dataset.titleText,
-					intro: step5.dataset.introText,
-				},
-			], 
-			showBullets: false, // カード展開がある都合上、ガイドステップのスキップ要制御
-			showProgress: true // Bulletsの代替となるガイド進行状況確認用UI
-		})
-
-	intro.onAfterChange((el) => {
-  	// console.log("今ハイライトしてるのは:", el)
-		// console.log(intro.getCurrentStep())
-
-		// 一番上にあるカードを展開し、カード内部(テクニック詳細画面)の説明をする。
-		if (intro.getCurrentStep() === 3) {
-			const firstCard = document.querySelector("a[data-turbo-frame='technique-drawer']");
-			if (firstCard) firstCard.click();
+		this.start(function () {
+			if (this.getCurrentStep() === 3) {
+				const firstCard = document.querySelector("a[data-turbo-frame='technique-drawer']");
+				if (firstCard) firstCard.click();
 			}
-	})
-		intro.start();
-		// console.log(intro)
+		});
 	}
 
 	startChartGuide() {
-		const step0 = document.querySelector("#step0")
-		const step1 = document.querySelector("#step1")
-		const step2 = document.querySelector("#step2")
-		const step3 = document.querySelector("#step3")
+		const controller = this; // ← Stimulusのthisを退避
 
-		const intro = introJs.tour().setOptions({
-			steps: [
-				{
-					intro: step0.dataset.introText
-				},
-				{
-					element: step1,
-					title: step1.dataset.titleText,
-					intro: step1.dataset.introText
-				},
-				{
-					element: step2,
-					title: step2.dataset.titleText,
-					intro: step2.dataset.introText
-				},
-				{ element: step3,
-					title: step3.dataset.titleText,
-					intro: step3.dataset.introText,
-					disableInteraction: true
-				},
-			], 
-			showBullets: false, 
-			showProgress: true
-		})
-
-		intro.onAfterChange(() => {
+		this.start(function() {
 			// step2の時、chart_controllerに頼んでドロワーを開く。
-			if (intro.getCurrentStep() === 2) {
-				this.dispatch("openNode");
+			if (this.getCurrentStep() === 2) {
+				controller.dispatch("openNode"); 
+				// アロー関数じゃないので、ここでthis.dispatchと書くとthisはtour()を指すようになる。
+				// アロー関数は外側のthisを使う一方、function() の場合thisは呼び出し側が決める仕様。
 			}
 		});
-
-		intro.start();
 	}
 
 	startNodeGuide(){
-		const step0 = document.querySelector("#step0n")
-		const step1 = document.querySelector("#step1n")
-		const step2 = document.querySelector("#step2n")
-		const step3 = document.querySelector("#step3n")
-		const step4 = document.querySelector("#step4n")
-
-		const intro = introJs.tour().setOptions({
-			steps: [
-				{
-					intro: step0.dataset.introText,
-					disableInteraction: true
-				},
-				{
-					element: step1,
-					title: step1.dataset.titleText,
-					intro: step1.dataset.introText,
-					disableInteraction: true
-				},
-				{
-					element: step2,
-					title: step2.dataset.titleText,
-					intro: step2.dataset.introText,
-					disableInteraction: true
-				},
-				{ 
-					element: step3,
-					title: step3.dataset.titleText,
-					intro: step3.dataset.introText,
-					disableInteraction: true
-				},
-				{
-					title: step4.dataset.titleText,
-					intro: step4.dataset.introText,
-					disableInteraction: true
-				},
-			], 
-			showBullets: false, 
-			showProgress: true
-		})
-
-		intro.onBeforeChange(() => {
-			intro.refresh();
+		this.start(function() {
+			this.refresh();
 			// 小さい画面だと最終ステップガイドが見切れるため、画面上部へ自動スクロール。
-			if (intro.getCurrentStep() === 4) {
+			if (this.getCurrentStep() === 4) {
 				window.scrollTo({ top: 0, behavior: "smooth" })
 			}
 		});
-
-		intro.start();
 	}
 }

--- a/app/javascript/i18n/loader.js
+++ b/app/javascript/i18n/loader.js
@@ -1,0 +1,43 @@
+import { I18n } from "i18n-js";
+
+let currentLocale = null;
+let initPromise = null;
+let i18n = null;
+
+function detectLocale() {
+	// URL /ja/... or <html lang="ja"> のどちらか
+	const lang = document.documentElement.getAttribute("lang");
+	if (lang) return lang;
+	const seg = location.pathname.split("/")[1];
+	return ["ja", "en"].includes(seg) ? seg : "ja";
+}
+
+async function importDict(locale) {
+	const raw = (await import(`../locales/${locale}.json`));
+  return raw[locale] // ロケール配下だけ返す
+}
+
+// 何度呼ばれても同じロケールなら再ロードしない
+export async function ensureI18n() {
+	const locale = detectLocale();
+	if (initPromise && currentLocale === locale) return initPromise;
+
+	initPromise = (async () => {
+		const dict = await importDict(locale);
+
+		if (!i18n) {
+			i18n = new I18n({ [locale]: dict });
+			i18n.defaultLocale = "ja";
+			i18n.locale = locale;
+			i18n.enableFallback = true;
+		} else {
+			i18n.translations = { [locale]: dict };
+			i18n.locale = locale;
+		}
+
+		return i18n;
+	})();
+
+	currentLocale = locale;
+	return initPromise;
+}

--- a/app/javascript/locales/en.json
+++ b/app/javascript/locales/en.json
@@ -1,21 +1,98 @@
 {
   "en": {
     "guides": {
-      "dashboard": {
+      "chart": {
         "step0": {
-          "intro_html": "This guide explains each menu shown on this page.",
-          "title": "Welcome!"
+          "intro_html": "This is the screen for visualizing connections between techniques.<br><br>You can place techniques here and create flowcharts."
         },
         "step1": {
-          "intro_html": "From this menu, you can view the list of techniques.\nDuring practice, record anything you notice for each technique.",
-          "title": "STEP 1"
+          "intro_html": "You can create a new starting point (root node) for your flowchart here.",
+          "selector": "#guide-creating-button",
+          "title": "New root node"
         },
         "step2": {
-          "intro_html": "From this menu, you can visualize technique progressions as a flow chart.<br>It helps you organize the flow of a match.",
-          "title": "STEP 2"
+          "intro_html": "Click a node (circle) on the chart to view or edit the technique’s details.",
+          "selector": ".drawer-side",
+          "title": "Techniques on the chart"
         },
         "step3": {
-          "intro_html": "That’s it for the menu overview.<br><br>\nIf you’re not sure where to start, open the\n<a class='underline font-bold' href=\"%{techniques_path}\">Technique</a> menu and click the icon at the top left:\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\n!"
+          "intro_html": "To learn more about operating this screen, click the\n<button type='button' class='underline' data-controller='step-guide' data-action='click->step-guide#startNodeGuide'>\n  <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 relative top-[3px]'>\n    <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n  </svg>\n</button> at the top left of the node editing screen.",
+          "selector": ".drawer-side",
+          "title": "Node editing"
+        }
+      },
+      "dashboard": {
+        "step0": {
+          "intro_html": "This guide will explain how to use the app.<br><br>\nThe basic flow of usage is as follows:<br><br>\n<ol class=\"list-decimal list-inside\">\n  <li>Register techniques in <strong>Technique</strong></li>\n  <li>Connect techniques in <strong>Flow Chart</strong> to visualize match developments (your preferred patterns)</li>\n</ol>",
+          "title": "About this guide"
+        },
+        "step1": {
+          "intro_html": "In <strong>Technique</strong>, you can register and organize your techniques.<br><br>\nAdding your insights from sparring to each technique’s note section will help reinforce learning.<br><br>\nOver 90 techniques are preloaded as presets, but feel free to add new ones if needed.<br><br>\nThe usage guide for the Technique screen can be opened by clicking the\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nicon at the top left of the Technique screen.<br><br>",
+          "selector": "#guide-technique",
+          "title": "Technique: Register techniques"
+        },
+        "step2": {
+          "intro_html": "In <strong>Flow Chart</strong>, you can connect the techniques registered in Technique and visualize match developments.<br><br>\nBy organizing “which technique can follow this one,” you can make reviews and strategy planning more effective.<br><br>\nThe usage guide for the Flow Chart screen can be opened by clicking the\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nicon at the top left of the Flow Chart screen.<br><br>",
+          "selector": "#guide-chart",
+          "title": "Flow Chart: Connect techniques"
+        },
+        "step3": {
+          "intro_html": "To start, try drawing the pathways of your preferred match developments in the <strong>Flow Chart</strong>.<br><br>If a technique you use is missing, go back to <strong>Technique</strong> and add it.",
+          "title": "First goal"
+        },
+        "step4": {
+          "intro_html": "Let’s get started!<br><br>\nIf you ever feel lost, you can always reopen this guide!",
+          "title": "All set!"
+        }
+      },
+      "node": {
+        "step0": {
+          "intro_html": "This section explains the node editing screen."
+        },
+        "step1": {
+          "intro_html": "Use this field to update the technique’s information.<br><br>Changes made here will also be reflected in the <a class='underline font-bold' href=\"%{techniques_path}\">Technique</a> list.",
+          "selector": "#guide-technique",
+          "title": "Update technique"
+        },
+        "step2": {
+          "intro_html": "Here you can edit which techniques branch out from this one.<br><br>The techniques you select will appear connected to the right of this technique on the chart.",
+          "selector": "#guide-children",
+          "title": "Update subsequent techniques"
+        },
+        "step3": {
+          "intro_html": "You can delete the node here.<br><br>Deleting a node will also remove all nodes that were connected as subsequent techniques, so please be careful.",
+          "selector": "#guide-deleting-button",
+          "title": "Delete node"
+        },
+        "step4": {
+          "intro_html": "Now try creating nodes and adding subsequent techniques to get familiar with the operations!<br><br>If you have any questions or suggestions about this app, feel free to contact us from the <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>contact page</a> at the bottom of the screen.<br><br>Enjoy your Jiu-Jitsu life! 👋"
+        }
+      },
+      "technique": {
+        "step0": {
+          "intro_html": "This is the screen where techniques are listed."
+        },
+        "step1": {
+          "intro_html": "If the technique you need isn’t listed, you can create a new one with this button.",
+          "selector": "#guide-creating-button",
+          "title": "New technique"
+        },
+        "step2": {
+          "intro_html": "You can search for techniques here to filter the list.",
+          "selector": "#guide-search-box",
+          "title": "Search"
+        },
+        "step3": {
+          "intro_html": "Click a card to view or edit details of an individual technique.",
+          "title": "Technique details"
+        },
+        "step4": {
+          "intro_html": "Use the note field here to record your daily training insights!",
+          "selector": ".drawer-side",
+          "title": "Technique details"
+        },
+        "step5": {
+          "intro_html": "That’s all for this screen.<br><br>If you’d like to learn how to connect techniques and visualize them, go to the <a class='underline font-bold' href=\"%{charts_path}\">Flow Chart</a> menu and click the\n  <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n    <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n  </svg>\nicon at the top left.<br><br>"
         }
       }
     }

--- a/app/javascript/locales/en.json
+++ b/app/javascript/locales/en.json
@@ -1,0 +1,23 @@
+{
+  "en": {
+    "guides": {
+      "dashboard": {
+        "step0": {
+          "intro_html": "This guide explains each menu shown on this page.",
+          "title": "Welcome!"
+        },
+        "step1": {
+          "intro_html": "From this menu, you can view the list of techniques.\nDuring practice, record anything you notice for each technique.",
+          "title": "STEP 1"
+        },
+        "step2": {
+          "intro_html": "From this menu, you can visualize technique progressions as a flow chart.<br>It helps you organize the flow of a match.",
+          "title": "STEP 2"
+        },
+        "step3": {
+          "intro_html": "That’s it for the menu overview.<br><br>\nIf you’re not sure where to start, open the\n<a class='underline font-bold' href=\"%{techniques_path}\">Technique</a> menu and click the icon at the top left:\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\n!"
+        }
+      }
+    }
+  }
+}

--- a/app/javascript/locales/ja.json
+++ b/app/javascript/locales/ja.json
@@ -1,0 +1,23 @@
+{
+  "ja": {
+    "guides": {
+      "dashboard": {
+        "step0": {
+          "intro_html": "このガイドでは、画面に表示されている各メニューについて説明します。",
+          "title": "ようこそ！"
+        },
+        "step1": {
+          "intro_html": "このメニューから、テクニック一覧を確認することができます。\n練習中に気がついたことをテクニックごとに記録しておきましょう。",
+          "title": "STEP 1"
+        },
+        "step2": {
+          "intro_html": "このメニューから、テクニックの展開を流れ図で可視化することができます。<br>試合の流れを整理するのに役立ちます。",
+          "title": "STEP 2"
+        },
+        "step3": {
+          "intro_html": "メニューの説明は以上です。<br><br>まず何をすればよいか分からない方は <a class='underline font-bold' href=\"%{techniques_path}\">Technique</a> メニューを開き、左上にある\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n<path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックしてみましょう！"
+        }
+      }
+    }
+  }
+}

--- a/app/javascript/locales/ja.json
+++ b/app/javascript/locales/ja.json
@@ -1,21 +1,99 @@
 {
   "ja": {
     "guides": {
-      "dashboard": {
+      "chart": {
         "step0": {
-          "intro_html": "このガイドでは、画面に表示されている各メニューについて説明します。",
-          "title": "ようこそ！"
+          "intro_html": "こちらは、テクニック同士の繋がりを可視化するための画面です。<br><br>このエリアにテクニックを配置し、フローチャートを作ることができます。"
         },
         "step1": {
-          "intro_html": "このメニューから、テクニック一覧を確認することができます。\n練習中に気がついたことをテクニックごとに記録しておきましょう。",
-          "title": "STEP 1"
+          "intro_html": "ここからフローチャートの開始点(ルートノード)を新規作成できます。",
+          "selector": "#guide-creating-button",
+          "title": "新規作成"
         },
         "step2": {
-          "intro_html": "このメニューから、テクニックの展開を流れ図で可視化することができます。<br>試合の流れを整理するのに役立ちます。",
-          "title": "STEP 2"
+          "intro_html": "エリアにあるノード(丸い図形)をクリックすると、テクニックの詳細を確認・編集することができます。",
+          "selector": ".drawer-side",
+          "title": "チャート上のテクニック"
         },
         "step3": {
-          "intro_html": "メニューの説明は以上です。<br><br>まず何をすればよいか分からない方は <a class='underline font-bold' href=\"%{techniques_path}\">Technique</a> メニューを開き、左上にある\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n<path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックしてみましょう！"
+          "intro_html": "本画面の操作について知りたい方は、ノード編集画面左上にある\n<button type='button' class='underline' data-controller='step-guide' data-action='click->step-guide#startNodeGuide'>\n  <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 relative top-[3px]'>\n    <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n  </svg>\n</button> をクリックしてください！",
+          "selector": ".drawer-side",
+          "title": "ノード編集"
+        }
+      },
+      "dashboard": {
+        "step0": {
+          "intro_html": "ここでは、アプリの使い方を説明します。<br><br>\n基本的な使い方の流れは以下の通りです。<br><br>\n<ol class=\"list-decimal list-inside\">\n  <li><strong>Technique</strong> で技を登録</li>\n  <li><strong>Flow Chart</strong> で技同士をつないで、試合の展開（得意パターン）を可視化</li>\n</ol>",
+          "title": "このガイドについて"
+        },
+        "step1": {
+          "intro_html": "<strong>Technique</strong>では、技を登録・整理することができます。<br><br>\nスパー後の気づきを各テクニックのノート部分に追記すると、技が定着しやすくなります。<br><br>\nプリセットとして90個以上のテクニックが初期登録されていますが、自分がよく使うテクニックがない場合は新規登録を行ってください。<br><br>\nTechniue画面の操作方法ガイドは、Technique画面左上の\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックすると表示されます。<br><br>\n<a class='underline font-bold' href=\"%{techniques_path}\">Technique を開く</a>",
+          "selector": "#guide-technique",
+          "title": "Technique：技を登録"
+        },
+        "step2": {
+          "intro_html": "<strong>Flow Chart</strong>では、Techniqueで登録した技を「次に何をするか」でつなげます。<br><br>\n分岐や得意ルートが可視化され、復習・戦略立案に役立ちます。<br><br>\nFlow Chart画面の操作方法ガイドは、Flow Chart画面左上の\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックすると表示されます。<br><br>\n<a class='underline font-bold' href=\"%{charts_path}\">Flow Chart を開く</a>",
+          "selector": "#guide-chart",
+          "title": "Flow Chart：技をつなぐ"
+        },
+        "step3": {
+          "intro_html": "まずは、<strong>Flow Chart</strong>で、自分が得意としている試合の動線を描いてみてください。<br><br>自分が使うテクニックがプリセットに用意されていない場合は、<strong>Technique</strong>に戻って、テクニックを新規追加してみてください。",
+          "title": "最初のゴール"
+        },
+        "step4": {
+          "intro_html": "それでは始めましょう！<br><br>\n分からなくなったら、もう一度このガイドを開けば大丈夫です！",
+          "title": "準備OK！"
+        }
+      },
+      "node": {
+        "step0": {
+          "intro_html": "ここでは、ノード編集画面について説明します。"
+        },
+        "step1": {
+          "intro_html": "このフィールドから、テクニックの情報を更新することができます。<br><br>この画面で更新された情報は、<a class='underline font-bold' href=\"%{techniques_path}\">Technique</a> 上の内容にも反映されます。",
+          "selector": "#guide-technique",
+          "title": "テクニック更新"
+        },
+        "step2": {
+          "intro_html": "このテクニックから展開される技を編集することができます。<br><br>ここで展開先として選択されたテクニックは、このテクニックの右側に接続される形でチャート上に描写されます。",
+          "selector": "#guide-children",
+          "title": "展開先テクニック更新"
+        },
+        "step3": {
+          "intro_html": "こちらからノードを削除することができます。<br><br>ノードを削除すると、展開先テクニックとして接続されていたノードもすべて削除されますので、ご注意ください。",
+          "selector": "#guide-deleting-button",
+          "title": "ノード削除"
+        },
+        "step4": {
+          "intro_html": "ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋\"",
+          "title": "ガイドが完了しました！お疲れ様です！"
+        }
+      },
+      "technique": {
+        "step0": {
+          "intro_html": "こちらは、柔術のテクニックが一覧として並んでいる画面です。"
+        },
+        "step1": {
+          "intro_html": "一覧にないテクニックは、こちらのボタンから新規作成することができます。",
+          "selector": "#guide-creating-button",
+          "title": "新規作成"
+        },
+        "step2": {
+          "intro_html": "一覧にあるテクニックは、ここから検索して表示を絞り込むことができます。",
+          "selector": "#guide-search-box",
+          "title": "検索"
+        },
+        "step3": {
+          "intro_html": "カードをクリックすると、テクニック個々の詳細を確認・編集することができます。",
+          "title": "テクニック詳細"
+        },
+        "step4": {
+          "intro_html": "こちらのノート欄に、日々の練習で気がついたことを記録していきましょう！",
+          "selector": ".drawer-side",
+          "title": "テクニック詳細"
+        },
+        "step5": {
+          "intro_html": "こちらの画面の説明は以上です。<br><br>本画面から確認できるテクニック同士を繋げて可視化する操作について知りたい場合は <a class='underline font-bold' href=\"%{charts_path}\"> Flow Chart</a> メニューの左上にある\n  <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n    <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n  </svg>\nをクリックしてください！"
         }
       }
     }

--- a/app/javascript/locales/ja.json
+++ b/app/javascript/locales/ja.json
@@ -27,17 +27,17 @@
           "title": "このガイドについて"
         },
         "step1": {
-          "intro_html": "<strong>Technique</strong>では、技を登録・整理することができます。<br><br>\nスパー後の気づきを各テクニックのノート部分に追記すると、技が定着しやすくなります。<br><br>\nプリセットとして90個以上のテクニックが初期登録されていますが、自分がよく使うテクニックがない場合は新規登録を行ってください。<br><br>\nTechniue画面の操作方法ガイドは、Technique画面左上の\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックすると表示されます。<br><br>\n<a class='underline font-bold' href=\"%{techniques_path}\">Technique を開く</a>",
+          "intro_html": "<strong>Technique</strong>では、技を登録・整理することができます。<br><br>\nスパー後の気づきを各テクニックのノート部分に追記すると、技が定着しやすくなります。<br><br>\nプリセットとして90個以上のテクニックが初期登録されていますが、足りない場合は新規登録を行ってください。<br><br>\nTechniue画面の操作方法ガイドは、Technique画面左上の\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックすると表示されます。<br><br>",
           "selector": "#guide-technique",
           "title": "Technique：技を登録"
         },
         "step2": {
-          "intro_html": "<strong>Flow Chart</strong>では、Techniqueで登録した技を「次に何をするか」でつなげます。<br><br>\n分岐や得意ルートが可視化され、復習・戦略立案に役立ちます。<br><br>\nFlow Chart画面の操作方法ガイドは、Flow Chart画面左上の\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックすると表示されます。<br><br>\n<a class='underline font-bold' href=\"%{charts_path}\">Flow Chart を開く</a>",
+          "intro_html": "<strong>Flow Chart</strong>では、Techniqueに登録された技同士を繋げて、試合の展開を可視化することができます。<br><br>\n「この技の次にどの技が使えるか」を整理することで、復習・戦略立案に役立てることができます。<br><br>\nFlow Chart画面の操作方法ガイドは、Flow Chart画面左上の\n<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>\n  <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />\n</svg>\nをクリックすると表示されます。<br><br>",
           "selector": "#guide-chart",
           "title": "Flow Chart：技をつなぐ"
         },
         "step3": {
-          "intro_html": "まずは、<strong>Flow Chart</strong>で、自分が得意としている試合の動線を描いてみてください。<br><br>自分が使うテクニックがプリセットに用意されていない場合は、<strong>Technique</strong>に戻って、テクニックを新規追加してみてください。",
+          "intro_html": "まずは、<strong>Flow Chart</strong>で、自分が得意としている試合の動線を描いてみてください。<br><br>自分が使うテクニックが用意されていない場合は、<strong>Technique</strong>に戻って、テクニックを新規追加してみてください。",
           "title": "最初のゴール"
         },
         "step4": {
@@ -65,8 +65,7 @@
           "title": "ノード削除"
         },
         "step4": {
-          "intro_html": "ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋\"",
-          "title": "ガイドが完了しました！お疲れ様です！"
+          "intro_html": "ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋\""
         }
       },
       "technique": {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-1EMLRGHCMZ"></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12A9 9 0 103 12a9 9 0 0018 0z" />
         </svg>
         <div>
-          <h3 class="font-bold">入力に誤りがあります</h3>
+          <h3 class="font-bold"><%= t("defaults.flash_messages.wrong_input") %></h3>
           <ul class="text-sm list-disc list-inside mt-1">
             <% Array(flash[:errors]).each do |msg| %>
               <li><%= msg %></li>

--- a/app/views/mypage/charts/show.html.erb
+++ b/app/views/mypage/charts/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div
   class="drawer drawer-end px-4 py-6 bg-base-100 space-y-6"
   data-controller="step-guide chart"
@@ -9,8 +10,8 @@
   <input type="checkbox" class="drawer-toggle" data-chart-target="toggle" />
   <div class="drawer-content">
     <div class="flex items-center space-x-2 m-4">
-      <h1 class="text-3xl font-bold ml-8">Flow Chart</h1>
-      <div class="tooltip" data-tip="ステップガイドを開始するにはここをクリック" data-action="click->step-guide#startChartGuide">
+      <h1 class="text-3xl font-bold ml-8"><%= t(".title") %></h1>
+      <div class="tooltip" data-tip="<%= t('defaults.start_guide') %>" data-action="click->step-guide#startChartGuide">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
         </svg>
@@ -28,7 +29,7 @@
         data-action="click->chart#addNode"
         data-title-text="新規作成"
         data-intro-text="ここからフローチャートの開始点(ルートノード)を新規作成できます。">
-        新しいフローを作る
+        <%= t(".create_nodes") %>
       </button>
       <!-- チャート描写用コンテナ -->
       <div data-chart-target="cy" class="h-full"></div>

--- a/app/views/mypage/charts/show.html.erb
+++ b/app/views/mypage/charts/show.html.erb
@@ -6,6 +6,7 @@
   data-chart-fetch-url-value="<%= api_v1_chart_path(@chart) %>"
   data-chart-edit-url-value="<%= edit_mypage_node_path(':id') %>"
   data-chart-add-url-value="<%= new_mypage_chart_node_path(@chart) %>"
+  data-step-guide-scope-value="guides.chart"
 >
   <input type="checkbox" class="drawer-toggle" data-chart-target="toggle" />
   <div class="drawer-content">
@@ -18,17 +19,14 @@
       </div>
     </div>
 
-    <div id="step0" class="hidden" data-intro-text="こちらは、テクニック同士の繋がりを可視化するための画面です。<br><br>このエリアにテクニックを配置し、フローチャートを作ることができます。"></div>
-
     <div class="mx-auto w-[90%] h-[60dvh] border border-base-300 relative min-h-0">
     <!-- z-1を使ってcyコンテナより手前に出しておかないとボタンが効かなくなる -->
       <button
-        id="step1"
+        id="guide-creating-button"
         type="button"
         class="btn btn-primary btn-wide absolute top-4 left-4 z-1" 
         data-action="click->chart#addNode"
-        data-title-text="新規作成"
-        data-intro-text="ここからフローチャートの開始点(ルートノード)を新規作成できます。">
+      >
         <%= t(".create_nodes") %>
       </button>
       <!-- チャート描写用コンテナ -->
@@ -38,26 +36,18 @@
 
   <div
     class="drawer-side"
-    id="step2"
-    data-title-text="チャート上のテクニック"
-    data-intro-text="エリアにあるノード(丸い図形)をクリックすると、テクニックの詳細を確認・編集することができます。"
   >
     <label aria-label="close sidebar" class="drawer-overlay" data-action="click->chart#closeDrawer" ></label>
 
     <!-- introjsで作成したガイドの要素は、本ファイルトップにあるdivタグに付与したdata-controller='step-guide' のスコープから外れる。その対策として、改めてdata-controller='step-guide'をintro-text内のbuttonタグに付与。 -->
     <!-- z-2を指定しないと、「新しいフローを作る」ボタンの下にドロワーが潜って表示されてしまう -->
     <aside
-      id="step3"
       class="flex flex-col bg-base-200 w-full sm:w-[32rem] max-w-[90vw] h-full overflow-y-auto p-4 z-2"
       role="dialog"
       aria-modal="true"
-      data-title-text="ノード編集"
-      data-intro-text="本画面の操作について知りたい方は、ノード編集画面左上にある
-        <button type='button' class='underline' data-controller='step-guide' data-action='click->step-guide#startNodeGuide'>
-          <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 relative top-[3px]'>
-            <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
-          </svg>
-        </button> をクリックしてください！"
+      data-controller="step-guide"
+      data-step-guide-scope-value="guides.node"
+      data-step-guide-techniques-path-value="<%= mypage_techniques_path %>"
     >
 
       <div class="flex p-3 justify-between items-center">

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:title, t(".title")) %>
-<div class="container mx-auto px-4 my-8" data-controller="step-guide">
+<div class="container mx-auto px-4 my-8"
+  data-controller="step-guide"
+  data-step-guide-scope-value="guides.dashboard"
+  data-step-guide-techniques-path-value="<%= mypage_techniques_path %>"
+>
   <!-- Hero -->
   <div class="hero shadow-lg mb-8">
     <div class="hero-content flex-col lg:flex-row">
@@ -9,7 +13,7 @@
         <p>本日も練習で学んだことを記録しましょう。</p>
         <p>本アプリの使い方については、以下のステップガイドをご参照ください。</p>
         <div class="flex justify-center">
-          <button data-action="click->step-guide#startMenuGuide" class="btn btn-primary btn-wide btn-lg my-10"><%= t(".start_guide") %></button>
+          <button data-action="click->step-guide#startDashboardGuide" class="btn btn-primary btn-wide btn-lg my-10"><%= t(".start_guide") %></button>
         </div>
       </div>
     </div>
@@ -22,8 +26,6 @@
     <!-- Technique -->
     <%= link_to mypage_techniques_path,
         id: "step1",
-        data: { title_text: "STEP 1",
-                intro_text: "このメニューから、テクニック一覧を確認することができます。<br>練習中に気がついたことをテクニックごとに記録しておきましょう。" },
         class: "card bg-base-100 hover:shadow-xl transition-shadow rounded-2xl" do %>
       <div class="card-body">
         <div class="flex items-start justify-between gap-4">
@@ -61,8 +63,6 @@
     <!-- Flow Chart -->
     <%= link_to mypage_chart_path(@chart.id),
         id: "step2",
-        data: { title_text: "STEP 2",
-                intro_text: "このメニューから、テクニックの展開を流れ図で可視化することができます。<br>試合の流れを整理するのに役立ちます。" },
         class: "card bg-base-100 hover:shadow-xl transition-shadow rounded-2xl" do %>
       <div class="card-body">
         <div class="flex items-start justify-between gap-4">
@@ -107,16 +107,5 @@
         <%= render "changelog" %>
       </div>
     </div>
-  </div>
-
-  <!-- step-guide用の非表示要素 -->
-  <div id="step0" data-title-text="ようこそ！" data-intro-text="このガイドでは、画面に表示されている各メニューについて説明します。" class="hidden"></div>
-  <div
-    id="step4"
-    data-intro-text="メニューの説明は以上です。<br><br>まず何をすればよいか分からない方は <a class='underline font-bold' href=<%= mypage_techniques_path %>>Technique</a> メニューを開き、左上にある
-      <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
-        <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
-      </svg>
-      をクリックしてみましょう！" class="hidden">
   </div>
 </div>

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -10,9 +10,9 @@
     <div class="hero-content flex-col lg:flex-row">
         <%= image_tag "icon.svg", alt: "icon", class: "w-85 h-auto"%>
       <div>
-        <h1 class="text-4xl font-bold mb-4">ようこそ、<br><%= current_user.name %>さん！</h1>
-        <p>本日も練習で学んだことを記録しましょう。</p>
-        <p>本アプリの使い方については、以下のステップガイドをご参照ください。</p>
+        <h1 class="text-4xl font-bold mb-4"><%= t(".welcome") %><br><%= t(".username", name: current_user.name) %></h1>
+        <p><%= t(".take_note") %></p>
+        <p><%= t(".check_howtouse") %></p>
         <div class="flex justify-center">
           <button data-action="click->step-guide#startDashboardGuide" class="btn btn-primary btn-wide btn-lg my-10"><%= t(".start_guide") %></button>
         </div>

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -3,6 +3,7 @@
   data-controller="step-guide"
   data-step-guide-scope-value="guides.dashboard"
   data-step-guide-techniques-path-value="<%= mypage_techniques_path %>"
+  data-step-guide-charts-path-value="<%= mypage_chart_path(current_user.charts.first) %>"
 >
   <!-- Hero -->
   <div class="hero shadow-lg mb-8">
@@ -25,7 +26,7 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
     <!-- Technique -->
     <%= link_to mypage_techniques_path,
-        id: "step1",
+        id: "guide-technique",
         class: "card bg-base-100 hover:shadow-xl transition-shadow rounded-2xl" do %>
       <div class="card-body">
         <div class="flex items-start justify-between gap-4">
@@ -62,7 +63,7 @@
 
     <!-- Flow Chart -->
     <%= link_to mypage_chart_path(@chart.id),
-        id: "step2",
+        id: "guide-chart",
         class: "card bg-base-100 hover:shadow-xl transition-shadow rounded-2xl" do %>
       <div class="card-body">
         <div class="flex items-start justify-between gap-4">

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="container mx-auto px-4 my-8" data-controller="step-guide">
   <!-- Hero -->
   <div class="hero shadow-lg mb-8">
@@ -8,7 +9,7 @@
         <p>本日も練習で学んだことを記録しましょう。</p>
         <p>本アプリの使い方については、以下のステップガイドをご参照ください。</p>
         <div class="flex justify-center">
-        <button data-action="click->step-guide#startMenuGuide" class="btn btn-primary btn-wide btn-lg my-10">ステップガイドを始める</button>
+          <button data-action="click->step-guide#startMenuGuide" class="btn btn-primary btn-wide btn-lg my-10"><%= t(".start_guide") %></button>
         </div>
       </div>
     </div>
@@ -38,15 +39,15 @@
               </svg>
             </div>
             <div>
-              <h3 class="font-semibold text-lg">Technique</h3>
-              <p class="text-sm opacity-70">技の一覧と練習メモを管理します。</p>
+              <h3 class="font-semibold text-lg"><%= t("headers.technique") %></h3>
+              <p class="text-sm opacity-70"><%= t(".technique_details") %></p>
             </div>
           </div>
   
           <!-- 右：メトリクス / 矢印 -->
           <div class="flex items-center gap-2">
             <!-- sm以下だとバッジ内で文字列が折り返してしまうので非表示 -->
-            <span class="sm:inline hidden badge badge-outline"><%= @technique_count %> テクニック</span>
+            <span class="sm:inline hidden badge badge-outline"><%= t(".metrics.techniques", count: @technique_count) %></span>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
                  fill="none" class="size-5 opacity-60 group-hover:opacity-100 transition">
               <path d="M9 5l7 7-7 7" stroke="currentColor" stroke-width="1.8"
@@ -80,13 +81,13 @@
             </div>
 
             <div>
-              <h3 class="font-semibold text-lg">Flow Chart</h3>
-              <p class="text-sm opacity-70">試合の流れを可視化します。</p>
+              <h3 class="font-semibold text-lg"><%= t("headers.flow_chart") %></h3>
+              <p class="text-sm opacity-70"><%= t(".chart_details") %></p>
             </div>
           </div>
 
           <div class="flex items-center gap-2">
-            <span class="sm:inline hidden badge badge-outline"><%= @node_count %> ノード</span>
+            <span class="sm:inline hidden badge badge-outline"><%= t(".metrics.nodes", count: @node_count) %></span>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
                  fill="none" class="size-5 opacity-60 group-hover:opacity-100 transition">
               <path d="M9 5l7 7-7 7" stroke="currentColor" stroke-width="1.8"
@@ -101,7 +102,7 @@
   <!-- 更新情報 -->
   <div class="card bg-base-200 shadow rounded-2xl">
     <div class="card-body p-4">
-      <h3 class="text-base font-semibold mb-2">更新情報</h3>
+      <h3 class="text-base font-semibold mb-2"><%= t(".updates") %></h3>
       <div class="h-80 overflow-y-auto pr-1 overscroll-contain">
         <%= render "changelog" %>
       </div>

--- a/app/views/mypage/nodes/_drawer_header.html.erb
+++ b/app/views/mypage/nodes/_drawer_header.html.erb
@@ -5,7 +5,7 @@
 <% if editing %>
   <div class="flex items-center m-4">
     <h2 class="text-lg font-bold mr-2"><%= t(".editing_panel_title") %></h2>
-    <div class="tooltip tooltip-right" data-tip="ステップガイドを開始" data-action="click->step-guide#startNodeGuide">
+    <div class="tooltip tooltip-right" data-tip="<%= t('defaults.start_guide') %>" data-action="click->step-guide#startNodeGuide">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
       </svg>

--- a/app/views/mypage/nodes/_drawer_header.html.erb
+++ b/app/views/mypage/nodes/_drawer_header.html.erb
@@ -4,7 +4,7 @@
 
 <% if editing %>
   <div class="flex items-center m-4">
-    <h2 class="text-lg font-bold mr-2">ノード編集</h2>
+    <h2 class="text-lg font-bold mr-2"><%= t(".editing_panel_title") %></h2>
     <div class="tooltip tooltip-right" data-tip="ステップガイドを開始" data-action="click->step-guide#startNodeGuide">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
@@ -12,5 +12,5 @@
     </div>
   </div>
 <% else %>
-  <h2 class="text-lg font-bold mr-2">フローの開始点を新規作成</h2>
+  <h2 class="text-lg font-bold mr-2"><%= t(".creating_panel_title") %></h2>
 <% end %>

--- a/app/views/mypage/nodes/edit.turbo_stream.erb
+++ b/app/views/mypage/nodes/edit.turbo_stream.erb
@@ -3,15 +3,11 @@
 <% end %>
 
 <%= turbo_stream.update "node-drawer" do %>
-  <div id="step0n" data-intro-text="ここでは、ノード編集画面について説明します。" class="hidden"></div>
-
   <%= form_with model: @form, url: mypage_node_path(@node), method: :patch do |f| %>
     <div class="flex flex-col items-center">
       <div 
-        id="step1n"
+        id="guide-technique"
         class="w-full"
-        data-title-text="テクニック更新"
-        data-intro-text="このフィールドから、テクニックの情報を更新することができます。<br><br>この画面で更新された情報は、<a class='underline font-bold' href='#{mypage_techniques_path}'>Technique</a> メニューの内容にも反映されます。"
       >
         <%= render 'mypage/techniques/form_core', f: f %>
       </div>
@@ -19,10 +15,8 @@
       <div class="divider my-8"></div>
 
       <div
-        id="step2n" 
+        id="guide-children"
         class="space-y-2 w-4/5 mx-auto"
-        data-title-text="展開先テクニック更新"
-        data-intro-text="このテクニックから展開される技を編集することができます。<br><br>ここで展開先として選択されたテクニックは、このテクニックの右側に接続される形でチャート上に描写されます。"
       >
         <%= f.label "children", t("helpers.label.children_nodes") %>
         <%= f.select "children",
@@ -42,23 +36,14 @@
       <%= f.submit t("helpers.submit.submit"), class: "btn btn-primary btn-wide", data: { turbo_frame: "_top" } %>
       <%= link_to t("defaults.delete_item", item: Node.model_name.human), 
         mypage_node_path(@node),
-        id: "step3n",
+        id: "guide-deleting-button",
         class: "btn btn-error btn-wide",
         data: { 
                 turbo_method: :delete,
                 turbo_confirm: t("defaults.delete_confirm"),
                 turbo_frame: "_top",
-                title_text: "ノード削除",
-                intro_text: "こちらからノードを削除することができます。<br><br>ノードを削除すると、展開先テクニックとして接続されていたノードもすべて削除されますので、ご注意ください。"
               }
       %>
     </div>
   <% end %>
-
-  <div
-  id="step4n"
-  data-title-text="ガイドが完了しました！お疲れ様です！"
-  data-intro-text="ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋" class="hidden"
-  >
-  </div>
 <% end %>

--- a/app/views/mypage/nodes/edit.turbo_stream.erb
+++ b/app/views/mypage/nodes/edit.turbo_stream.erb
@@ -24,13 +24,13 @@
         data-title-text="展開先テクニック更新"
         data-intro-text="このテクニックから展開される技を編集することができます。<br><br>ここで展開先として選択されたテクニックは、このテクニックの右側に接続される形でチャート上に描写されます。"
       >
-        <%= f.label "children", "展開先テクニック" %>
+        <%= f.label "children", t("helpers.label.children_nodes") %>
         <%= f.select "children",
             grouped_options_for_select(@grouped, @selected_ids),
             {},
             id: "children_nodes",
             multiple: true,
-            placeholder: "テクニックを検索",
+            placeholder: t("defaults.search"),
             data: { controller: "tom-select" }
         %>
       </div>
@@ -39,14 +39,14 @@
     <div class="divider my-8"></div>
 
     <div class="flex flex-col items-center space-y-2 my-10">
-      <%= f.submit "保存", class: "btn btn-primary btn-wide", data: { turbo_frame: "_top" } %>
-      <%= link_to "ノードを削除", 
+      <%= f.submit t("helpers.submit.submit"), class: "btn btn-primary btn-wide", data: { turbo_frame: "_top" } %>
+      <%= link_to t("defaults.delete_item", item: Node.model_name.human), 
         mypage_node_path(@node),
         id: "step3n",
         class: "btn btn-error btn-wide",
         data: { 
                 turbo_method: :delete,
-                turbo_confirm: "本当に削除しますか？",
+                turbo_confirm: t("defaults.delete_confirm"),
                 turbo_frame: "_top",
                 title_text: "ノード削除",
                 intro_text: "こちらからノードを削除することができます。<br><br>ノードを削除すると、展開先テクニックとして接続されていたノードもすべて削除されますので、ご注意ください。"

--- a/app/views/mypage/nodes/new.turbo_stream.erb
+++ b/app/views/mypage/nodes/new.turbo_stream.erb
@@ -5,19 +5,19 @@
 <%= turbo_stream.update "node-drawer" do %>
   <%= form_with url: mypage_chart_nodes_path(@chart), method: :post, class: "space-y-2 mt-10 w-4/5 mx-auto" do |f| %>
     <div class="flex items-center space-x-2">
-      <%= label_tag "root_nodes", "開始点テクニック" %>
-      <div class="badge badge-sm badge-error badge-outline">必須</div>
+      <%= label_tag "root_nodes", t("helpers.label.root_nodes") %>
+      <div class="badge badge-sm badge-error badge-outline"><%= t("form.required") %></div>
     </div>
     <%= select_tag "node[roots]",
           grouped_options_for_select(@grouped),
           id: "root_nodes",
           multiple: true,
-          placeholder: "テクニックを検索",
+          placeholder: t("defaults.search"),
           data: { controller: "tom-select" }
     %>
 
     <div class="flex justify-center">
-      <%= f.submit "追加", class: "btn btn-secondary btn-wide", data: { turbo_frame: "_top" } %>
+      <%= f.submit t("helpers.submit.create"), class: "btn btn-secondary btn-wide", data: { turbo_frame: "_top" } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/mypage/techniques/_form_core.html.erb
+++ b/app/views/mypage/techniques/_form_core.html.erb
@@ -1,16 +1,16 @@
   <div class="space-y-4 w-4/5 mx-auto">
     <div class="space-y-2 mb-4">
       <div class="flex items-center space-x-2">
-        <%= f.label :name, "テクニック名" %>
-        <div class="badge badge-sm badge-error badge-outline">必須</div>
+        <%= f.label :name, t("helpers.label.technique_name") %>
+        <div class="badge badge-sm badge-error badge-outline"><%= t("form.required") %></div>
       </div>
       <%= f.text_field :name_ja, class: "input input-bordered w-full" %>
   
-      <%= f.label :note, "ノート" %>
+      <%= f.label :note, t("helpers.label.note") %>
       <%= f.text_area :note, class: "textarea textarea-bordered w-full field-sizing-content
 " %>
   
-      <%= f.label :category, "カテゴリー" %>
-      <%= f.select :category, Technique.categories.keys.map { |c| [c.humanize, c] }, { include_blank: "未分類" }, class: "select select-bordered w-full" %>
+      <%= f.label :category, t("helpers.label.category") %>
+      <%= f.select :category, Technique.categories.keys.map { |c| [t("enums.category.#{c}"), c] }, { include_blank: t("enums.category.nil") }, class: "select select-bordered w-full" %>
     </div>
   </div>

--- a/app/views/mypage/techniques/edit.html.erb
+++ b/app/views/mypage/techniques/edit.html.erb
@@ -5,8 +5,8 @@
     </div>
   
     <div class="flex flex-col items-center space-y-2 my-10">
-      <%= f.submit "保存", class: "btn btn-primary btn-wide", data: { turbo_frame: "_top" } %>
-      <%= link_to '削除', mypage_technique_path(@technique.id), class: "btn btn-error btn-wide", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", turbo_frame: "_top" } %>
+      <%= f.submit t("helpers.submit.update"), class: "btn btn-primary btn-wide", data: { turbo_frame: "_top" } %>
+      <%= link_to t("defaults.delete"), mypage_technique_path(@technique.id), class: "btn btn-error btn-wide", data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm"), turbo_frame: "_top" } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/mypage/techniques/index.html.erb
+++ b/app/views/mypage/techniques/index.html.erb
@@ -2,6 +2,8 @@
 <div
   class="drawer drawer-end min-h-screen px-4 py-6 bg-base-100 space-y-6"
   data-controller="step-guide drawer"
+  data-step-guide-scope-value="guides.technique"
+  data-step-guide-charts-path-value="<%= mypage_chart_path(current_user.charts.first) %>"
 >
   <input type="checkbox" class="drawer-toggle" data-drawer-target="toggle">
 
@@ -15,16 +17,12 @@
       </div>
     </div>
 
-    <div id="step0" class="hidden" data-intro-text="こちらは、柔術のテクニックが一覧として並んでいる画面です。"></div>
-
     <div class="flex flex-col items-center justify-center gap-3">
-      <%= link_to t("defaults.create") , new_mypage_technique_path, class: "btn btn-primary btn-wide", id: "step1", data: { title_text: "新規作成", intro_text: "一覧にないテクニックは、こちらのボタンから新規作成することができます。" } %>
-      <%= search_form_for @q, url: mypage_techniques_path, id: "step2", class: "w-80",
+      <%= link_to t("defaults.create") , new_mypage_technique_path, class: "btn btn-primary btn-wide", id: "guide-creating-button" %>
+      <%= search_form_for @q, url: mypage_techniques_path, id: "guide-search-box", class: "w-80",
             data: { turbo_frame: "technique-list",
                     controller: "instant-search",
-                    action: "input->instant-search#autosubmit",
-                    title_text: "検索",
-                    intro_text: "一覧にあるテクニックは、ここから検索して表示を絞り込むことができます。"
+                    action: "input->instant-search#autosubmit"
             } do |f| %>
         <label class="input">
           <svg class="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -42,19 +40,6 @@
           <%= f.search_field :name_ja_or_name_en_or_note_cont, placeholder: t("defaults.search"), class: "search" %>
         </label>
       <% end %>
-    </div>
-
-    <div id="step3" data-title-text="テクニック詳細" data-intro-text="カードをクリックすると、テクニック個々の詳細を確認・編集することができます。" class="hidden"></div>
-    <div id="step4" data-title-text="テクニック詳細" data-intro-text="こちらのノート欄に、日々の練習で気がついたことを記録していきましょう！" class="hidden"></div>
-    <div
-      id="step5"
-      data-intro-text="こちらの画面の説明は以上です。<br><br>本画面から確認できるテクニック同士を繋げて可視化する操作について知りたい場合は <a class='underline font-bold' href=<%= mypage_chart_path(@chart) %>>Flow Chart</a> メニューの左上にある
-        <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
-          <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
-        </svg>
-      をクリックしてください！"
-      class="hidden"
-    >
     </div>
 
     <%= turbo_frame_tag "technique-list" do %>

--- a/app/views/mypage/techniques/index.html.erb
+++ b/app/views/mypage/techniques/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div
   class="drawer drawer-end min-h-screen px-4 py-6 bg-base-100 space-y-6"
   data-controller="step-guide drawer"
@@ -6,7 +7,7 @@
 
   <div class="drawer-content">
     <div class="flex items-center space-x-2 m-4">
-      <h1 class="text-3xl font-bold ml-8">Technique</h1>
+      <h1 class="text-3xl font-bold ml-8"><%= t(".title") %></h1>
       <div class="tooltip" data-tip="ステップガイドを開始するにはここをクリック" data-action="click->step-guide#startTechniqueGuide">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
@@ -17,7 +18,7 @@
     <div id="step0" class="hidden" data-intro-text="こちらは、柔術のテクニックが一覧として並んでいる画面です。"></div>
 
     <div class="flex flex-col items-center justify-center gap-3">
-      <%= link_to "新規作成" , new_mypage_technique_path, class: "btn btn-primary btn-wide", id: "step1", data: { title_text: "新規作成", intro_text: "一覧にないテクニックは、こちらのボタンから新規作成することができます。" } %>
+      <%= link_to t("defaults.create") , new_mypage_technique_path, class: "btn btn-primary btn-wide", id: "step1", data: { title_text: "新規作成", intro_text: "一覧にないテクニックは、こちらのボタンから新規作成することができます。" } %>
       <%= search_form_for @q, url: mypage_techniques_path, id: "step2", class: "w-80",
             data: { turbo_frame: "technique-list",
                     controller: "instant-search",
@@ -38,7 +39,7 @@
               <path d="m21 21-4.3-4.3"></path>
             </g>
           </svg>
-          <%= f.search_field :name_ja_or_name_en_or_note_cont, placeholder: "技またはノートを検索", class: "search" %>
+          <%= f.search_field :name_ja_or_name_en_or_note_cont, placeholder: t("defaults.search"), class: "search" %>
         </label>
       <% end %>
     </div>
@@ -60,50 +61,48 @@
       <div class="space-y-2 max-w-screen-2xl mx-auto mt-10">
         <% if @techniques.present? %>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2 max-w-screen-2xl mx-auto">
-          <% @techniques.each do |technique| %>
+          <% @techniques.each do |t| %>
             <article class="relative bg-base-200 shadow-md rounded-box p-4 space-y-3">
               <div class="items-start space-y-2 flex flex-col">
-                <% case technique.category %>
+                <% case t.category %>
                 <% when "submission" then %>
-                  <span class="badge badge-soft bg-red-100"><%= technique.category.humanize %></span>
+                  <span class="badge badge-soft bg-red-100"><%= t("enums.category.#{t.category}") %></span>
                 <% when "sweep" then %>
-                  <span class="badge badge-soft bg-blue-100"><%= technique.category.humanize %></span>
+                  <span class="badge badge-soft bg-blue-100"><%= t("enums.category.#{t.category}") %></span>
 
                 <% when "pass" then %>
-                  <span class="badge badge-soft bg-green-100"><%= technique.category.humanize %></span>
+                  <span class="badge badge-soft bg-green-100"><%= t("enums.category.#{t.category}") %></span>
 
                 <% when "guard" then %>
-                  <span class="badge badge-soft bg-gray-100"><%= technique.category.humanize %></span>
+                  <span class="badge badge-soft bg-gray-100"><%= t("enums.category.#{t.category}") %></span>
 
                 <% when "control" then %>
-                  <span class="badge badge-soft bg-purple-100"><%= technique.category.humanize %></span>
+                  <span class="badge badge-soft bg-purple-100"><%= t("enums.category.#{t.category}") %></span>
 
                 <% when "takedown" then %>
-                  <span class="badge badge-soft bg-orange-100"><%= technique.category.humanize %></span>
+                  <span class="badge badge-soft bg-orange-100"><%= t("enums.category.#{t.category}") %></span>
                 <% else %>
-                  <span class="badge badge-soft"><%= technique.category ? technique.category.humanize : "未分類" %></span>
+                  <span class="badge badge-soft"><%= t.category ? t("enums.category.#{t.category}") : t("enums.category.nil") %></span>
                 <% end %>
-                <span class="text-lg font-medium" ><%= technique.name_ja %></span>
+                <span class="text-lg font-medium" ><%= t.name_ja %></span>
               </div>
 
-              <!-- noteを表示に含めると、カードの厚みが変わってしまう 
-              <% if technique.note.present? %>
-                <p class="text-sm text-base-content/70 line-clamp-3 break-words"><%= technique.note %></p>
+              <% if t.note.present? %>
+                <p class="text-sm text-base-content/70 line-clamp-3 break-words"><%= t.note %></p>
               <% end %>
-              -->
 
               <!-- カード全面クリックでdrawerを開く & 中身を読み込む（stretched-link的アンカー） -->
-              <%= link_to edit_mypage_technique_path(technique),
+              <%= link_to edit_mypage_technique_path(t),
                     class: "absolute inset-0 z-10",
                     data: { turbo_frame: "technique-drawer", action: "click->drawer#open" } do %>
-                <span class="sr-only">編集を開く</span>
+                <span class="sr-only">Open the editing panel</span>
               <% end %>
             </article>
           <% end %>
           </div>
         <% else %>
           <div class="mt-10">
-            <p>表示するテクニックがありません。</p>
+            <p><%= t(".nothing_here") %></p>
           </div>
         <% end %>
       </div>
@@ -117,7 +116,7 @@
     <!-- パネル本体（SP=全幅, PC=28rem） -->
     <aside class="bg-base-200 w-full sm:w-[28rem] max-w-[90vw] h-full overflow-y-auto" role="dialog" aria-modal="true">
       <div class="flex flex-end justify-between p-3">
-        <h2 class="text-lg font-bold mr-2">テクニック編集</h2>
+        <h2 class="text-lg font-bold mr-2"><%= t(".editing_panel_title") %></h2>
         <!-- ✕ボタン（クリックで閉じる） -->
         <label class="btn btn-sm btn-circle btn-ghost " data-action="click->drawer#close">✕</label>
       </div>

--- a/app/views/mypage/techniques/index.html.erb
+++ b/app/views/mypage/techniques/index.html.erb
@@ -8,7 +8,7 @@
   <div class="drawer-content">
     <div class="flex items-center space-x-2 m-4">
       <h1 class="text-3xl font-bold ml-8"><%= t(".title") %></h1>
-      <div class="tooltip" data-tip="ステップガイドを開始するにはここをクリック" data-action="click->step-guide#startTechniqueGuide">
+      <div class="tooltip" data-tip="<%= t('defaults.start_guide') %>" data-action="click->step-guide#startTechniqueGuide">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
         </svg>

--- a/app/views/mypage/techniques/new.html.erb
+++ b/app/views/mypage/techniques/new.html.erb
@@ -1,10 +1,11 @@
-<h2 class="text-lg font-bold m-4">新しいテクニックを作成</h2>
+<% content_for(:title, t(".title")) %>
+<h2 class="text-lg font-bold m-4"><%= t(".title") %></h2>
 <%= form_with model: @technique, url: @technique.persisted? ? mypage_technique_path(@technique) : mypage_techniques_path, method: @technique.persisted? ? :patch : :post do |f| %>
   <%= render "shared/error_messages", object: @technique %>
   <%= render "form_core", f: f %>
 
   <div class="flex flex-col items-center space-y-4 w-72 mx-auto">
-    <%= f.submit "保存", class: "btn btn-primary btn-wide" %>
-    <%= link_to '一覧へ戻る', mypage_techniques_path, class: "btn btn-outline btn-wide" %>
+    <%= f.submit t("helpers.submit.create"), class: "btn btn-primary btn-wide" %>
+    <%= link_to t("defaults.back"), mypage_techniques_path, class: "btn btn-outline btn-wide" %>
   </div>
 <% end %>

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -3,26 +3,26 @@
     <%= image_tag "icon.svg", alt: "icon", class: "w-100 h-auto mx-auto"%>
     <div>
       <h1 class="font-bebas text-5xl font-bold"><%= base_title %></h1>
-      <h3 class="text-lg font-bold">技は点でなく、“流れ”で覚える</h3>
+      <h3 class="text-lg font-bold"><%= t(".hero.catchphrase") %></h3>
       <p class="py-6">
-        <%= base_title %> は、ブラジリアン柔術のテクニックをフローチャート形式で整理・可視化できるツールです。
+        <%= t(".hero.description", app_name: base_title) %>
       </p>
 
       <div class="flex space-x-3">
         <% if user_signed_in? %>
-          <button type="button" class="btn btn-disabled">ログイン済みです</button>
+          <button type="button" class="btn btn-disabled"><%= t(".hero.already_signed_in") %></button>
         <% else %>
           <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "btn btn-outline bg-white" do %>
             <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g><path d="m0 0H512V512H0" fill="#fff"></path><path fill="#34a853" d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"></path><path fill="#4285f4" d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"></path><path fill="#fbbc02" d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"></path><path fill="#ea4335" d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"></path></g></svg>
             <span><%= t("shared.sign_in_with", provider: t("shared.providers.google")) %></span>
           <% end %>
         <% end %>
-        <%#= link_to "デモを触ってみる", "#", class: "btn btn-primary shwdow-md" %>
-        <button class="btn bg-base-300 shadow" onclick="my_modal_1.showModal()">デモを触ってみる</button>
+        <%#= link_to t(".hero.cta_demo"), "#", class: "btn btn-primary shadow-md" %>
+        <button class="btn bg-base-300 shadow" onclick="my_modal_1.showModal()"><%= t(".hero.cta_demo") %></button>
         <dialog id="my_modal_1" class="modal">
           <div class="modal-box">
-            <h3 class="text-lg font-bold">本機能は、現時点で未実装です。</h3>
-            <p class="py-4">利用にあたっては、Googleアカウントでログインしてください。<br></p>
+            <h3 class="text-lg font-bold"><%= t(".hero.demo_modal.title") %></h3>
+            <p class="py-4"><%= t(".hero.demo_modal.body") %></p>
           </div>
           <form method="dialog" class="modal-backdrop">
             <button>close</button>
@@ -35,29 +35,29 @@
 
   <section id="features" class="py-20">
     <div class="max-w-7xl mx-auto px-4">
-      <h2 class="text-3xl md:text-4xl font-bold text-center">主な機能</h2>
-      <p class="text-center opacity-70 mt-2">技の整理からゲームプラン作成まで、これ1つでOK</p>
+      <h2 class="text-3xl md:text-4xl font-bold text-center"><%= t(".features.heading") %></h2>
+      <p class="text-center opacity-70 mt-2"><%= t(".features.subheading") %></p>
 
       <div class="mt-12 grid sm:grid-cols-1 lg:grid-cols-3 gap-6">
         <div class="card bg-base-100 border border-base-300/60 shadow-sm">
           <div class="card-body">
             <div class="text-3xl">📌</div>
-            <h3 class="card-title">テクニックの記録</h3>
-            <p class="opacity-80">習った技を追加。カテゴリー（パス/スイープ/サブミッション等）で整理し、学んだ内容をノートに保存。</p>
+            <h3 class="card-title"><%= t(".features.cards.record.title") %></h3>
+            <p class="opacity-80"><%= t(".features.cards.record.body") %></p>
           </div>
         </div>
         <div class="card bg-base-100 border border-base-300/60 shadow-sm">
           <div class="card-body">
             <div class="text-3xl">🔗</div>
-            <h3 class="card-title">フローで可視化</h3>
-            <p class="opacity-80">技と技を線でつなぎ、<span class="font-semibold">フローチャート</span>を作成。試合・スパーのシナリオ作りに。</p>
+            <h3 class="card-title"><%= t(".features.cards.flow.title") %></h3>
+            <p class="opacity-80"><%= t(".features.cards.flow.body") %></p>
           </div>
         </div>
         <div class="card bg-base-100 border border-base-300/60 shadow-sm">
           <div class="card-body">
             <div class="text-3xl">🚀</div>
-            <h3 class="card-title">テンプレから成長</h3>
-            <p class="opacity-80">テンプレートをベースに自分専用へ。練習を重ねるほど柔術マップが育ちます。</p>
+            <h3 class="card-title"><%= t(".features.cards.grow_from_templates.title") %></h3>
+            <p class="opacity-80"><%= t(".features.cards.grow_from_templates.body") %></p>
           </div>
         </div>
       </div>
@@ -67,50 +67,50 @@
   <!-- Use cases / Benefits -->
   <section id="usecases" class="py-20 bg-base-200/60">
     <div class="max-w-7xl mx-auto px-4">
-      <h2 class="text-3xl md:text-4xl font-bold text-center">こんな使い方ができます</h2>
+      <h2 class="text-3xl md:text-4xl font-bold text-center"><%= t(".usecases.heading") %></h2>
       <div class="mt-12 grid md:grid-cols-3 gap-6">
         <div class="card bg-base-100 shadow-sm border border-base-300/60">
           <div class="card-body">
-            <h3 class="card-title">学習ログ</h3>
-            <p class="opacity-80">その日に習った技をすぐ追加。関連する展開をつなげて復習がラクに。</p>
+            <h3 class="card-title"><%= t(".usecases.cards.study_log.title") %></h3>
+            <p class="opacity-80"><%= t(".usecases.cards.study_log.body") %></p>
           </div>
         </div>
         <div class="card bg-base-100 shadow-sm border border-base-300/60">
           <div class="card-body">
-            <h3 class="card-title">ゲームプラン作成</h3>
-            <p class="opacity-80">得意技を起点に、<span class="font-semibold">ガード→スイープ→パス→極め</span>のルートを設計。</p>
+            <h3 class="card-title"><%= t(".usecases.cards.game_plan.title") %></h3>
+            <p class="opacity-80"><%= t(".usecases.cards.game_plan.body") %></p>
           </div>
         </div>
         <div class="card bg-base-100 shadow-sm border border-base-300/60">
           <div class="card-body">
-            <h3 class="card-title">大会前の仕上げ</h3>
-            <p class="opacity-80">狙う展開をチャートでシミュレーション。迷いを減らし、当日集中できます。</p>
+            <h3 class="card-title"><%= t(".usecases.cards.pre_comp.title") %></h3>
+            <p class="opacity-80"><%= t(".usecases.cards.pre_comp.body") %></p>
           </div>
         </div>
       </div>
 
       <div class="mt-12 grid lg:grid-cols-2 gap-8 items-center">
         <ul class="steps steps-vertical lg:steps-horizontal w-full">
-          <li class="step step-primary" data-content="1">技を登録</li>
-          <li class="step step-primary" data-content="2">つなげてフロー化</li>
-          <li class="step step-primary" data-content="3">全体像を確認</li>
-          <li class="step step-primary" data-content="4">練習で更新</li>
+          <li class="step step-primary" data-content="1"><%= t(".usecases.steps.register") %></li>
+          <li class="step step-primary" data-content="2"><%= t(".usecases.steps.connect") %></li>
+          <li class="step step-primary" data-content="3"><%= t(".usecases.steps.overview") %></li>
+          <li class="step step-primary" data-content="4"><%= t(".usecases.steps.update") %></li>
         </ul>
         <div class="stats shadow">
           <div class="stat">
-            <div class="stat-title">初期の登録技</div>
-            <div class="stat-value">80+</div>
-            <div class="stat-desc">自分のペースで増やせます</div>
+            <div class="stat-title"><%= t(".usecases.stats.initial_techniques.title") %></div>
+            <div class="stat-value"><%= t(".usecases.stats.initial_techniques.value") %></div>
+            <div class="stat-desc"><%= t(".usecases.stats.initial_techniques.desc") %></div>
           </div>
           <div class="stat">
-            <div class="stat-title">フロー分岐</div>
-            <div class="stat-value">無制限</div>
-            <div class="stat-desc">自由に設計</div>
+            <div class="stat-title"><%= t(".usecases.stats.flow_branches.title") %></div>
+            <div class="stat-value"><%= t(".usecases.stats.flow_branches.value") %></div>
+            <div class="stat-desc"><%= t(".usecases.stats.flow_branches.desc") %></div>
           </div>
           <div class="stat">
-            <div class="stat-title">対応端末</div>
-            <div class="stat-value">PC / モバイル</div>
-            <div class="stat-desc">どこでも復習</div>
+            <div class="stat-title"><%= t(".usecases.stats.devices.title") %></div>
+            <div class="stat-value"><%= t(".usecases.stats.devices.value") %></div>
+            <div class="stat-desc"><%= t(".usecases.stats.devices.desc") %></div>
           </div>
         </div>
       </div>
@@ -120,30 +120,30 @@
   <!-- How to start -->
   <section id="howto" class="py-20">
     <div class="max-w-5xl mx-auto px-4">
-      <h2 class="text-3xl md:text-4xl font-bold text-center">はじめ方</h2>
+      <h2 class="text-3xl md:text-4xl font-bold text-center"><%= t(".howto.heading") %></h2>
       <div class="mt-12 grid md:grid-cols-2 gap-6">
         <div class="card bg-base-100 border border-base-300/60 shadow-sm">
           <div class="card-body">
-            <h3 class="card-title">1. まずはテンプレから</h3>
-            <p class="opacity-80">用意されたテンプレートチャートをベースに、自分の得意技を追加してみましょう。</p>
+            <h3 class="card-title"><%= t(".howto.cards.step1.title") %></h3>
+            <p class="opacity-80"><%= t(".howto.cards.step1.body") %></p>
           </div>
         </div>
         <div class="card bg-base-100 border border-base-300/60 shadow-sm">
           <div class="card-body">
-            <h3 class="card-title">2. 自分の言葉でメモ</h3>
-            <p class="opacity-80">細かいコツ・注意点をノートに。練習後すぐに更新すると定着が早いです。</p>
+            <h3 class="card-title"><%= t(".howto.cards.step2.title") %></h3>
+            <p class="opacity-80"><%= t(".howto.cards.step2.body") %></p>
           </div>
         </div>
         <div class="card bg-base-100 border border-base-300/60 shadow-sm">
           <div class="card-body">
-            <h3 class="card-title">3. 展開をつなぐ</h3>
-            <p class="opacity-80">ノード同士を線でつなぎ、試合やスパーの展開をそのまま可視化しましょう。</p>
+            <h3 class="card-title"><%= t(".howto.cards.step3.title") %></h3>
+            <p class="opacity-80"><%= t(".howto.cards.step3.body") %></p>
           </div>
         </div>
         <div class="card bg-base-100 border border-base-300/60 shadow-sm">
           <div class="card-body">
-            <h3 class="card-title">4. 定期的に見返す</h3>
-            <p class="opacity-80">スパー前にチャートを確認。作戦を明確にして臨むことができます。</p>
+            <h3 class="card-title"><%= t(".howto.cards.step4.title") %></h3>
+            <p class="opacity-80"><%= t(".howto.cards.step4.body") %></p>
           </div>
         </div>
       </div>
@@ -153,23 +153,23 @@
   <!-- CTA -->
   <section id="get-started" class="py-20 bg-base-200/60">
     <div class="max-w-4xl mx-auto px-4 text-center">
-      <h2 class="text-3xl md:text-4xl font-bold">今すぐ、あなたの柔術マップを作ろう</h2>
-      <p class="mt-3 opacity-80">登録は1分、すぐにチャート作成へ。</p>
+      <h2 class="text-3xl md:text-4xl font-bold"><%= t(".cta.heading") %></h2>
+      <p class="mt-3 opacity-80"><%= t(".cta.subheading") %></p>
       <div class="mt-6 flex justify-center gap-3">
         <% if user_signed_in? %>
-          <button type="button" class="btn btn-disabled">ログイン済みです</button>
+          <button type="button" class="btn btn-disabled"><%= t(".hero.already_signed_in") %></button>
         <% else %>
           <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "btn btn-outline bg-white" do %>
             <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g><path d="m0 0H512V512H0" fill="#fff"></path><path fill="#34a853" d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"></path><path fill="#4285f4" d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"></path><path fill="#fbbc02" d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"></path><path fill="#ea4335" d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"></path></g></svg>
             <span><%= t("shared.sign_in_with", provider: t("shared.providers.google")) %></span>
           <% end %>
         <% end %>
-        <%#= link_to "デモを触ってみる", "#", class: "btn btn-primary w-72 shwdow-md" %>
-          <button class="btn bg-base-300 shadow" onclick="my_modal_2.showModal()">デモを触ってみる</button>
+        <%#= link_to t(".hero.cta_demo"), "#", class: "btn btn-primary w-72 shadow-md" %>
+          <button class="btn bg-base-300 shadow" onclick="my_modal_2.showModal()"><%= t(".hero.cta_demo") %></button>
           <dialog id="my_modal_2" class="modal">
             <div class="modal-box">
-              <h3 class="text-lg font-bold">本機能については、現段階で未実装です。</h3>
-              <p class="py-4">利用にあたっては、Googleアカウントでログインしてください。<br></p>
+              <h3 class="text-lg font-bold"><%= t(".hero.demo_modal.title") %></h3>
+              <p class="py-4"><%= t(".hero.demo_modal.body") %></p>
             </div>
             <form method="dialog" class="modal-backdrop">
               <button>close</button>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -4,7 +4,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12A9 9 0 103 12a9 9 0 0018 0z" />
     </svg>
     <div>
-      <h3 class="font-bold">入力に誤りがあります</h3>
+      <h3 class="font-bold"><%= t("defaults.flash_messages.wrong_input") %></h3>
       <ul class="text-sm list-disc list-inside mt-1">
         <% object.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,8 +1,8 @@
 <footer class="footer footer-horizontal footer-center bg-base-200 text-base-content rounded p-6">
   <nav class="md:grid md:grid-flow-col gap-4">
-      <%= link_to t("footer.inquiry"), "https://forms.gle/VGdTkDDsJkVQY7e79", class: "link link-hover" %>
-      <%= link_to t("footer.privacy"), privacy_path, class: "link link-hover" %>
-    <div class="tooltip" data-tip="このページは準備中です！">
+    <%= link_to t("footer.inquiry"), "https://forms.gle/VGdTkDDsJkVQY7e79", class: "link link-hover" %>
+    <%= link_to t("footer.privacy"), privacy_path, class: "link link-hover" %>
+    <div class="tooltip" data-tip=<%= t("defaults.preparing") %>>
       <a class="link link-hover"><%= t("footer.terms") %></a>
     </div>
   </nav>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,9 +1,9 @@
 <footer class="footer footer-horizontal footer-center bg-base-200 text-base-content rounded p-6">
   <nav class="md:grid md:grid-flow-col gap-4">
-      <%= link_to "お問い合わせ", "https://forms.gle/VGdTkDDsJkVQY7e79", class: "link link-hover" %>
-      <%= link_to "プライバシーポリシー", privacy_path, class: "link link-hover" %>
+      <%= link_to t("footer.inquiry"), "https://forms.gle/VGdTkDDsJkVQY7e79", class: "link link-hover" %>
+      <%= link_to t("footer.privacy"), privacy_path, class: "link link-hover" %>
     <div class="tooltip" data-tip="このページは準備中です！">
-      <a class="link link-hover">利用規約</a>
+      <a class="link link-hover"><%= t("footer.terms") %></a>
     </div>
   </nav>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,10 +19,10 @@
   <div class="hidden lg:flex lg:flex-2 items-center lg:justify-end">
     <% if user_signed_in? %>
       <div class="hidden lg:flex lg:gap-x-10 items-center lg:mr-16">
-        <%= link_to "Home", root_path, class: "font-semibold hover:underline" %>
-        <%= link_to "Technique", mypage_techniques_path, class: "font-semibold hover:underline" %>
-        <%= link_to "Flow Chart", mypage_chart_path(@chart), class: "font-semibold hover:underline" %>
-        <%= link_to "Dashboard", mypage_root_path, class: "font-semibold hover:underline" %>
+        <%= link_to t("header.home"), root_path, class: "font-semibold hover:underline" %>
+        <%= link_to t("header.technique"), mypage_techniques_path, class: "font-semibold hover:underline" %>
+        <%= link_to t("header.flow_chart"), mypage_chart_path(@chart), class: "font-semibold hover:underline" %>
+        <%= link_to t("header.dashboard"), mypage_root_path, class: "font-semibold hover:underline" %>
       </div>
       <div class="avatar mr-2">
         <div class="w-10 rounded-full">
@@ -32,7 +32,7 @@
       <div class="hidden md:mr-6 md:block">
         <p><%= current_user.name %></p>
       </div>
-      <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "btn bg-active bg-base-300 font-semibold py-2 px-4" %>
+      <%= link_to t("header.logout"), destroy_user_session_path, data: { turbo_method: :delete }, class: "btn bg-active bg-base-300 font-semibold py-2 px-4" %>
     <% else %>
       <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "btn btn-outline bg-white" do %>
         <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g><path d="m0 0H512V512H0" fill="#fff"></path><path fill="#34a853" d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"></path><path fill="#4285f4" d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"></path><path fill="#fbbc02" d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"></path><path fill="#ea4335" d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"></path></g></svg>
@@ -63,10 +63,10 @@
           <div class="-my-6 divide-y divide-gray-500/10">
             <% if user_signed_in? %>
               <div class="space-y-2 py-6">
-                <%= link_to "Home", root_path, class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300"  %>
-                <%= link_to "Technique", mypage_techniques_path, class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300" %>
-                <%= link_to "Flow Chart", mypage_chart_path(@chart), class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300" %>
-                <%= link_to "Dashboard", mypage_root_path, class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300" %>
+                <%= link_to t("header.home"), root_path, class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300"  %>
+                <%= link_to t("header.technique"), mypage_techniques_path, class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300" %>
+                <%= link_to t("header.flow_chart"), mypage_chart_path(@chart), class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300" %>
+                <%= link_to t("header.dashboard"), mypage_root_path, class: "-mx-3 block rounded-lg px-3 py-2 font-semibold hover:bg-base-300" %>
               </div>
             <% end %>
             <div class="py-6 flex items-center">

--- a/bin/render-build.dev.sh
+++ b/bin/render-build.dev.sh
@@ -1,6 +1,7 @@
 set -o errexit
 
 bundle install
+bundle exec i18n export
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate:reset

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,6 +1,7 @@
 set -o errexit
 
 bundle install
+bundle exec i18n export
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate

--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -1,0 +1,9 @@
+---
+translations:
+  - file: app/javascript/locales.json
+    patterns:
+      - "*"
+      - "!*.activerecord"
+      - "!*.errors"
+      - "!*.number.nth"
+

--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -1,9 +1,5 @@
 ---
 translations:
-  - file: app/javascript/locales.json
+  - file: "app/javascript/locales/:locale.json"
     patterns:
-      - "*"
-      - "!*.activerecord"
-      - "!*.errors"
-      - "!*.number.nth"
-
+      - "*.guides.*"

--- a/config/locales/activemodel/en.yml
+++ b/config/locales/activemodel/en.yml
@@ -1,0 +1,9 @@
+en:
+  activemodel:
+    attributes:
+      node_edit_form:
+        name_ja: Technique Name (Japanese)
+        name_en: Technique Name (English)
+        category: Category
+        note: Note
+        children: Subsequent Techniques

--- a/config/locales/activerecord/en.yml
+++ b/config/locales/activerecord/en.yml
@@ -1,0 +1,30 @@
+en:
+  activerecord:
+    models:
+      user: User
+      technique_preset: Technique Preset
+      technique: Technique
+      chart: Chart
+      node: Node
+    attributes:
+      user: 
+        name: Username
+        email: Email Address
+        image: Avatar
+      chart:
+        name: Chart Name
+      technique:
+        name_ja: Technique Name (Japanese)
+        name_en: Technique Name (English)
+        category: Category
+        note: Note
+  enums:
+    category:
+      submission: Submission
+      sweep: Sweep
+      pass: Pass
+      guard: Guard
+      control: Control
+      takedown: Takedown
+      nil: Uncategorized
+

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -20,7 +20,7 @@ ja:
         note: ノート
   enums:
     category:
-      submission: サブミッション
+      submission: 極め技
       sweep: スイープ
       pass: パス
       guard: ガード

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -18,3 +18,12 @@ ja:
         name_en: テクニック名(英語)
         category: カテゴリー
         note: ノート
+  enums:
+    category:
+      submission: サブミッション
+      sweep: スイープ
+      pass: パス
+      guard: ガード
+      control: コントロール
+      takedown: テイクダウン
+      nil: 未分類

--- a/config/locales/guides/en.yml
+++ b/config/locales/guides/en.yml
@@ -2,23 +2,108 @@ en:
   guides:
     dashboard:
       step0:
-        title: "Welcome!"
-        intro_html: "This guide explains each menu shown on this page."
+        title: "About this guide"
+        intro_html: |-
+          This guide will explain how to use the app.<br><br>
+          The basic flow of usage is as follows:<br><br>
+          <ol class="list-decimal list-inside">
+            <li>Register techniques in <strong>Technique</strong></li>
+            <li>Connect techniques in <strong>Flow Chart</strong> to visualize match developments (your preferred patterns)</li>
+          </ol>
       step1:
-        title: "STEP 1"
+        title: "Technique: Register techniques"
+        selector: "#guide-technique"
         intro_html: |-
-          From this menu, you can view the list of techniques.
-          During practice, record anything you notice for each technique.
-      step2:
-        title: "STEP 2"
-        intro_html: |-
-          From this menu, you can visualize technique progressions as a flow chart.<br>It helps you organize the flow of a match.
-      step3:
-        intro_html: |-
-          That’s it for the menu overview.<br><br>
-          If you’re not sure where to start, open the
-          <a class='underline font-bold' href="%{techniques_path}">Technique</a> menu and click the icon at the top left:
+          In <strong>Technique</strong>, you can register and organize your techniques.<br><br>
+          Adding your insights from sparring to each technique’s note section will help reinforce learning.<br><br>
+          Over 90 techniques are preloaded as presets, but feel free to add new ones if needed.<br><br>
+          The usage guide for the Technique screen can be opened by clicking the
           <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
             <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
           </svg>
-          !
+          icon at the top left of the Technique screen.<br><br>
+      step2:
+        title: "Flow Chart: Connect techniques"
+        selector: "#guide-chart"
+        intro_html: |-
+          In <strong>Flow Chart</strong>, you can connect the techniques registered in Technique and visualize match developments.<br><br>
+          By organizing “which technique can follow this one,” you can make reviews and strategy planning more effective.<br><br>
+          The usage guide for the Flow Chart screen can be opened by clicking the
+          <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
+            <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+          </svg>
+          icon at the top left of the Flow Chart screen.<br><br>
+      step3:
+        title: "First goal"
+        intro_html: |-
+          To start, try drawing the pathways of your preferred match developments in the <strong>Flow Chart</strong>.<br><br>If a technique you use is missing, go back to <strong>Technique</strong> and add it.
+      step4:
+        title: "All set!"
+        intro_html: |-
+          Let’s get started!<br><br>
+          If you ever feel lost, you can always reopen this guide!
+    technique:
+      step0:
+        intro_html: "This is the screen where techniques are listed."
+      step1:
+        title: "New technique"
+        selector: "#guide-creating-button"
+        intro_html: "If the technique you need isn’t listed, you can create a new one with this button."
+      step2:
+        title: "Search"
+        selector: "#guide-search-box"
+        intro_html: "You can search for techniques here to filter the list."
+      step3:
+        title: "Technique details"
+        intro_html: "Click a card to view or edit details of an individual technique."
+      step4:
+        title: "Technique details"
+        selector: ".drawer-side"
+        intro_html: "Use the note field here to record your daily training insights!"
+      step5:
+        intro_html: |-
+          That’s all for this screen.<br><br>If you’d like to learn how to connect techniques and visualize them, go to the <a class='underline font-bold' href="%{charts_path}">Flow Chart</a> menu and click the
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
+              <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+            </svg>
+          icon at the top left.<br><br>
+    chart:
+      step0:
+        intro_html: "This is the screen for visualizing connections between techniques.<br><br>You can place techniques here and create flowcharts."
+      step1:
+        title: "New root node"
+        selector: "#guide-creating-button"
+        intro_html: "You can create a new starting point (root node) for your flowchart here."
+      step2:
+        title: "Techniques on the chart"
+        selector: ".drawer-side"
+        intro_html: "Click a node (circle) on the chart to view or edit the technique’s details."
+      step3:
+        title: "Node editing"
+        selector: ".drawer-side"
+        intro_html: |-
+          To learn more about operating this screen, click the
+          <button type='button' class='underline' data-controller='step-guide' data-action='click->step-guide#startNodeGuide'>
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 relative top-[3px]'>
+              <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+            </svg>
+          </button> at the top left of the node editing screen.
+    node:
+      step0:
+        intro_html: "This section explains the node editing screen."
+      step1:
+        title: "Update technique"
+        selector: "#guide-technique"
+        intro_html: |-
+          Use this field to update the technique’s information.<br><br>Changes made here will also be reflected in the <a class='underline font-bold' href="%{techniques_path}">Technique</a> list.
+      step2:
+        title: "Update subsequent techniques"
+        selector: "#guide-children"
+        intro_html: "Here you can edit which techniques branch out from this one.<br><br>The techniques you select will appear connected to the right of this technique on the chart."
+      step3:
+        title: "Delete node"
+        selector: "#guide-deleting-button"
+        intro_html: "You can delete the node here.<br><br>Deleting a node will also remove all nodes that were connected as subsequent techniques, so please be careful."
+      step4:
+        intro_html: |-
+          Now try creating nodes and adding subsequent techniques to get familiar with the operations!<br><br>If you have any questions or suggestions about this app, feel free to contact us from the <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>contact page</a> at the bottom of the screen.<br><br>Enjoy your Jiu-Jitsu life! 👋

--- a/config/locales/guides/en.yml
+++ b/config/locales/guides/en.yml
@@ -1,0 +1,24 @@
+en:
+  guides:
+    dashboard:
+      step0:
+        title: "Welcome!"
+        intro_html: "This guide explains each menu shown on this page."
+      step1:
+        title: "STEP 1"
+        intro_html: |-
+          From this menu, you can view the list of techniques.
+          During practice, record anything you notice for each technique.
+      step2:
+        title: "STEP 2"
+        intro_html: |-
+          From this menu, you can visualize technique progressions as a flow chart.<br>It helps you organize the flow of a match.
+      step3:
+        intro_html: |-
+          That’s it for the menu overview.<br><br>
+          If you’re not sure where to start, open the
+          <a class='underline font-bold' href="%{techniques_path}">Technique</a> menu and click the icon at the top left:
+          <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
+            <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+          </svg>
+          !

--- a/config/locales/guides/ja.yml
+++ b/config/locales/guides/ja.yml
@@ -1,0 +1,22 @@
+ja:
+  guides:
+    dashboard:
+      step0:
+        title: "ようこそ！" 
+        intro_html: "このガイドでは、画面に表示されている各メニューについて説明します。"
+      step1:
+        title: "STEP 1"
+        intro_html: >-
+          このメニューから、テクニック一覧を確認することができます。<br><br>
+          練習中に気がついたことをテクニックごとに記録しておきましょう。
+      step2:
+        title: "STEP 2"
+        intro_html: >-
+          このメニューから、テクニックの展開を流れ図で可視化することができます。<br><br>試合の流れを整理するのに役立ちます。
+      step3:
+        intro_html: |-
+          メニューの説明は以上です。<br><br>まず何をすればよいか分からない方は <a class='underline font-bold' href="%{techniques_path}">Technique</a> メニューを開き、左上にある
+          <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
+          <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+          </svg>
+          をクリックしてみましょう！

--- a/config/locales/guides/ja.yml
+++ b/config/locales/guides/ja.yml
@@ -16,29 +16,27 @@ ja:
         intro_html: |-
           <strong>Technique</strong>では、技を登録・整理することができます。<br><br>
           スパー後の気づきを各テクニックのノート部分に追記すると、技が定着しやすくなります。<br><br>
-          プリセットとして90個以上のテクニックが初期登録されていますが、自分がよく使うテクニックがない場合は新規登録を行ってください。<br><br>
+          プリセットとして90個以上のテクニックが初期登録されていますが、足りない場合は新規登録を行ってください。<br><br>
           Techniue画面の操作方法ガイドは、Technique画面左上の
           <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
             <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
           </svg>
           をクリックすると表示されます。<br><br>
-          <a class='underline font-bold' href="%{techniques_path}">Technique を開く</a>
       step2:
         title: "Flow Chart：技をつなぐ"
         selector: "#guide-chart"
         intro_html: |-
-          <strong>Flow Chart</strong>では、Techniqueで登録した技を「次に何をするか」でつなげます。<br><br>
-          分岐や得意ルートが可視化され、復習・戦略立案に役立ちます。<br><br>
+          <strong>Flow Chart</strong>では、Techniqueに登録された技同士を繋げて、試合の展開を可視化することができます。<br><br>
+          「この技の次にどの技が使えるか」を整理することで、復習・戦略立案に役立てることができます。<br><br>
           Flow Chart画面の操作方法ガイドは、Flow Chart画面左上の
           <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
             <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
           </svg>
           をクリックすると表示されます。<br><br>
-          <a class='underline font-bold' href="%{charts_path}">Flow Chart を開く</a>
       step3:
         title: "最初のゴール"
         intro_html: |-
-          まずは、<strong>Flow Chart</strong>で、自分が得意としている試合の動線を描いてみてください。<br><br>自分が使うテクニックがプリセットに用意されていない場合は、<strong>Technique</strong>に戻って、テクニックを新規追加してみてください。
+          まずは、<strong>Flow Chart</strong>で、自分が得意としている試合の動線を描いてみてください。<br><br>自分が使うテクニックが用意されていない場合は、<strong>Technique</strong>に戻って、テクニックを新規追加してみてください。
       step4:
         title: "準備OK！"
         intro_html: |-
@@ -107,6 +105,5 @@ ja:
         selector: "#guide-deleting-button"
         intro_html: "こちらからノードを削除することができます。<br><br>ノードを削除すると、展開先テクニックとして接続されていたノードもすべて削除されますので、ご注意ください。"
       step4:
-        title: "ガイドが完了しました！お疲れ様です！"
         intro_html: |-
           ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋"

--- a/config/locales/guides/ja.yml
+++ b/config/locales/guides/ja.yml
@@ -2,21 +2,111 @@ ja:
   guides:
     dashboard:
       step0:
-        title: "ようこそ！" 
-        intro_html: "このガイドでは、画面に表示されている各メニューについて説明します。"
-      step1:
-        title: "STEP 1"
-        intro_html: >-
-          このメニューから、テクニック一覧を確認することができます。<br><br>
-          練習中に気がついたことをテクニックごとに記録しておきましょう。
-      step2:
-        title: "STEP 2"
-        intro_html: >-
-          このメニューから、テクニックの展開を流れ図で可視化することができます。<br><br>試合の流れを整理するのに役立ちます。
-      step3:
+        title: "このガイドについて"
         intro_html: |-
-          メニューの説明は以上です。<br><br>まず何をすればよいか分からない方は <a class='underline font-bold' href="%{techniques_path}">Technique</a> メニューを開き、左上にある
+          ここでは、アプリの使い方を説明します。<br><br>
+          基本的な使い方の流れは以下の通りです。<br><br>
+          <ol class="list-decimal list-inside">
+            <li><strong>Technique</strong> で技を登録</li>
+            <li><strong>Flow Chart</strong> で技同士をつないで、試合の展開（得意パターン）を可視化</li>
+          </ol>
+      step1:
+        title: "Technique：技を登録"
+        selector: "#guide-technique"
+        intro_html: |-
+          <strong>Technique</strong>では、技を登録・整理することができます。<br><br>
+          スパー後の気づきを各テクニックのノート部分に追記すると、技が定着しやすくなります。<br><br>
+          プリセットとして90個以上のテクニックが初期登録されていますが、自分がよく使うテクニックがない場合は新規登録を行ってください。<br><br>
+          Techniue画面の操作方法ガイドは、Technique画面左上の
           <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
-          <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+            <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
           </svg>
-          をクリックしてみましょう！
+          をクリックすると表示されます。<br><br>
+          <a class='underline font-bold' href="%{techniques_path}">Technique を開く</a>
+      step2:
+        title: "Flow Chart：技をつなぐ"
+        selector: "#guide-chart"
+        intro_html: |-
+          <strong>Flow Chart</strong>では、Techniqueで登録した技を「次に何をするか」でつなげます。<br><br>
+          分岐や得意ルートが可視化され、復習・戦略立案に役立ちます。<br><br>
+          Flow Chart画面の操作方法ガイドは、Flow Chart画面左上の
+          <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
+            <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+          </svg>
+          をクリックすると表示されます。<br><br>
+          <a class='underline font-bold' href="%{charts_path}">Flow Chart を開く</a>
+      step3:
+        title: "最初のゴール"
+        intro_html: |-
+          まずは、<strong>Flow Chart</strong>で、自分が得意としている試合の動線を描いてみてください。<br><br>自分が使うテクニックがプリセットに用意されていない場合は、<strong>Technique</strong>に戻って、テクニックを新規追加してみてください。
+      step4:
+        title: "準備OK！"
+        intro_html: |-
+          それでは始めましょう！<br><br>
+          分からなくなったら、もう一度このガイドを開けば大丈夫です！
+    technique:
+      step0:
+        intro_html: "こちらは、柔術のテクニックが一覧として並んでいる画面です。"
+      step1:
+        title: "新規作成"
+        selector: "#guide-creating-button"
+        intro_html: "一覧にないテクニックは、こちらのボタンから新規作成することができます。"
+      step2:
+        title: "検索"
+        selector: "#guide-search-box"
+        intro_html: "一覧にあるテクニックは、ここから検索して表示を絞り込むことができます。"
+      step3:
+        title: "テクニック詳細"
+        intro_html: "カードをクリックすると、テクニック個々の詳細を確認・編集することができます。" 
+      step4:
+        title: "テクニック詳細"
+        selector: ".drawer-side"
+        intro_html: "こちらのノート欄に、日々の練習で気がついたことを記録していきましょう！" 
+      step5:
+        intro_html: |-
+          こちらの画面の説明は以上です。<br><br>本画面から確認できるテクニック同士を繋げて可視化する操作について知りたい場合は <a class='underline font-bold' href="%{charts_path}"> Flow Chart</a> メニューの左上にある
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 inline'>
+              <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+            </svg>
+          をクリックしてください！
+    chart:
+      step0:
+        intro_html: "こちらは、テクニック同士の繋がりを可視化するための画面です。<br><br>このエリアにテクニックを配置し、フローチャートを作ることができます。"
+      step1:
+        title: "新規作成"
+        selector: "#guide-creating-button"
+        intro_html: "ここからフローチャートの開始点(ルートノード)を新規作成できます。"
+      step2:
+        title: "チャート上のテクニック"
+        selector: ".drawer-side"
+        intro_html: "エリアにあるノード(丸い図形)をクリックすると、テクニックの詳細を確認・編集することができます。"
+      step3:
+        title: "ノード編集"
+        selector: ".drawer-side"
+        intro_html: |-
+          本画面の操作について知りたい方は、ノード編集画面左上にある
+          <button type='button' class='underline' data-controller='step-guide' data-action='click->step-guide#startNodeGuide'>
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='size-6 relative top-[3px]'>
+              <path stroke-linecap='round' stroke-linejoin='round' d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z' />
+            </svg>
+          </button> をクリックしてください！
+    node:
+      step0:
+        intro_html: "ここでは、ノード編集画面について説明します。"
+      step1:
+        title: "テクニック更新"
+        selector: "#guide-technique"
+        intro_html: |-
+          このフィールドから、テクニックの情報を更新することができます。<br><br>この画面で更新された情報は、<a class='underline font-bold' href="%{techniques_path}">Technique</a> 上の内容にも反映されます。
+      step2:
+        title: "展開先テクニック更新"
+        selector: "#guide-children"
+        intro_html: "このテクニックから展開される技を編集することができます。<br><br>ここで展開先として選択されたテクニックは、このテクニックの右側に接続される形でチャート上に描写されます。"
+      step3:
+        title: "ノード削除"
+        selector: "#guide-deleting-button"
+        intro_html: "こちらからノードを削除することができます。<br><br>ノードを削除すると、展開先テクニックとして接続されていたノードもすべて削除されますので、ご注意ください。"
+      step4:
+        title: "ガイドが完了しました！お疲れ様です！"
+        intro_html: |-
+          ここまで来たら、試しにノードを作ったり、展開先テクニックを追加したりして操作に慣れましょう！<br><br>本アプリに関するご不明点や改善点等がございましたら、画面下部にある <a class='underline font-bold' href='https://forms.gle/VGdTkDDsJkVQY7e79' target='_blank' rel='noopener noreferrer'>お問い合わせ</a> ページよりお気軽にご連絡ください！<br><br>それでは、よりよい柔術ライフを👋"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -29,6 +29,7 @@ en:
     delete_confirm: "Are you sure you want to delete?"
     back: "Back to List"
     start_guide: "Start Step Guide"
+    preparing: "It is currently under construction!"
     flash_messages:
       created: "%{item} was successfully created"
       not_created: "Failed to create %{item}"
@@ -67,6 +68,10 @@ en:
     dashboard:
       show:
         title: Dashboard
+        welcome: "Welcome,"
+        username: "%{name}!"
+        take_note: "Let's record what you learned in practice today.”"
+        check_howtouse: "For instructions on how to use this app, please refer to the Step-By-Step Guide below."
         start_guide: "Start Step Guide"
         updates: Updates
         technique_details: "Manage your techniques and training notes."

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1,0 +1,81 @@
+en:
+  terms:
+    root_nodes: "Flow Starting Point"
+    children_nodes: "Transitions"
+  shared:
+    sign_in_with: "Sign in with %{provider}"
+    providers:
+      google: "Google"
+  form:
+    required: Required
+  helpers:
+    submit:
+      create: Create
+      submit: Save
+      update: Update
+    label:
+      technique_name: "Technique Name"
+      note: Note
+      category: Category
+      children_nodes: "Transitions"
+      root_nodes: "Root Technique"
+  defaults:
+    create: New
+    search: "Search Techniques"
+    edit: Edit
+    show: Details
+    delete: Delete
+    delete_item: "Delete %{item}"
+    delete_confirm: "Are you sure you want to delete?"
+    back: "Back to List"
+    start_guide: "Start Step Guide"
+    flash_messages:
+      created: "%{item} was successfully created"
+      not_created: "Failed to create %{item}"
+      updated: "%{item} was successfully updated"
+      not_updated: "Failed to update %{item}"
+      deleted: "%{item} was successfully deleted"
+      multiple_select: "Please select one or more %{item}"
+      require_login: "Please sign in"
+      wrong_input: "There are errors in your input"
+  header:
+    home: Home
+    technique: Technique
+    flow_chart: "Flow Chart"
+    dashboard: Dashboard
+    logout: Logout
+  footer:
+    inquiry: Contact
+    privacy: "Privacy Policy"
+    terms: "Terms of Service"
+  mypage:
+    techniques:
+      index:
+        title: "Techniques"
+        nothing_here: "No techniques to display"
+        editing_panel_title: "Edit Technique"
+      new:
+        title: "Create a New Technique"
+    charts:
+      show:
+        title: "Flow Chart"
+        create_nodes: "Create a New Flow"
+    nodes:
+      drawer_header:
+        editing_panel_title: "Edit Node"
+        creating_panel_title: "Create Starting Point"
+    dashboard:
+      show:
+        title: Dashboard
+        start_guide: "Start Step Guide"
+        updates: Updates
+        technique_details: "Manage your techniques and training notes."
+        chart_details: "Visualize match or sparring flows."
+        metrics:
+          techniques:
+            one: "%{count} technique"
+            other: "%{count} techniques"
+          nodes:
+            one: "%{count} node"
+            other: "%{count} nodes"
+

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -78,4 +78,74 @@ en:
           nodes:
             one: "%{count} node"
             other: "%{count} nodes"
-
+  pages:
+    top:
+      hero:
+        catchphrase: "Learn techniques as flows, not isolated moves"
+        description: "%{app_name} lets you organize and visualize Brazilian Jiu-Jitsu techniques as flowcharts."
+        cta_demo: "Try the demo"
+        already_signed_in: "You're already signed in"
+        demo_modal:
+          title: "This feature is not implemented yet."
+          body: "To use the service, please sign in with your Google account."
+      features:
+        heading: "Key Features"
+        subheading: "From organizing techniques to building your game plan—all in one place."
+        cards:
+          record:
+            title: "Record Techniques"
+            body: "Add techniques you learn. Organize them by category (pass/sweep/submission, etc.) and save notes."
+          flow:
+            title: "Visualize as Flows"
+            body: "Connect techniques to create a flowchart—ideal for planning matches and sparring."
+          grow_from_templates:
+            title: "Grow from Templates"
+            body: "Start from a template and make it your own. Your Jiu-Jitsu map grows as you train."
+      usecases:
+        heading: "How You Can Use It"
+        cards:
+          study_log:
+            title: "Study Log"
+            body: "Quickly add techniques learned that day. Link related transitions for easier review."
+          game_plan:
+            title: "Build a Game Plan"
+            body: "Design paths from your strengths — guard → sweep → pass → finish."
+          pre_comp:
+            title: "Pre-competition Prep"
+            body: "Simulate target sequences as a chart to reduce hesitation and stay focused on the day."
+        steps:
+          register: "Register techniques"
+          connect: "Connect and create flows"
+          overview: "See the big picture"
+          update: "Update after training"
+        stats:
+          initial_techniques:
+            title: "Initial techniques"
+            value: "90+"
+            desc: "Add more at your own pace"
+          flow_branches:
+            title: "Flow branches"
+            value: "Unlimited"
+            desc: "Design freely"
+          devices:
+            title: "Supported devices"
+            value: "Desktop / Mobile"
+            desc: "Review anywhere"
+      howto:
+        heading: "Getting Started"
+        cards:
+          step1:
+            title: "1. Start from a template"
+            body: "Use a template chart as a base and add your favorite techniques."
+          step2:
+            title: "2. Take notes in your own words"
+            body: "Capture tips and cautions. Updating right after practice improves retention."
+          step3:
+            title: "3. Link transitions"
+            body: "Connect nodes to visualize match or sparring sequences as they are."
+          step4:
+            title: "4. Review regularly"
+            body: "Before a match or roll, check your chart so you can go in with a clear plan."
+      cta:
+        heading: "Build your Jiu-Jitsu map now"
+        subheading: "Sign-up takes a minute—start charting right away."

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -28,6 +28,7 @@ ja:
     delete_item: "%{item}を削除"
     delete_confirm: 削除しますか？
     back: 一覧へ戻る
+    start_guide: ステップガイドを開始
     flash_messages:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
@@ -63,4 +64,16 @@ ja:
       drawer_header:
         editing_panel_title: ノードを編集
         creating_panel_title: フローの開始点を作成
+    dashboard:
+      show:
+        title: Dashboard
+        start_guide: ステップガイドを始める
+        updates: 更新情報
+        technique_details: "技の一覧と練習メモを管理します。"
+        chart_details: "試合またはスパーの流れを可視化します。" 
+        metrics:
+          techniques: 
+            other: "%{count} テクニック"
+          nodes:
+            other: "%{count} ノード"
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,13 +20,14 @@ ja:
       children_nodes: 展開先テクニック
       root_nodes: 開始点テクニック
   defaults:
-    create: 作成
+    create: 新規作成
     search: テクニックを検索
     edit: 編集
     show: 詳細
     delete: 削除
     delete_item: "%{item}を削除"
     delete_confirm: 削除しますか？
+    back: 一覧へ戻る
     flash_messages:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
@@ -45,3 +46,11 @@ ja:
     inquiry: お問い合わせ
     privacy: プライバシーポリシー
     terms: 利用規約
+  mypage:
+    techniques:
+      index:
+        title: Technique 
+        nothing_here: 表示するテクニックがありません
+        editing_panel_title: テクニック編集
+      new: 
+        title: 新規テクニック作成

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -76,4 +76,75 @@ ja:
             other: "%{count} テクニック"
           nodes:
             other: "%{count} ノード"
+  pages:
+    top:
+      hero:
+        catchphrase: "技は点でなく、“流れ”で覚える"
+        description: "%{app_name} は、ブラジリアン柔術のテクニックをフローチャート形式で整理・可視化できるツールです。"
+        cta_demo: "デモを触ってみる"
+        already_signed_in: "ログイン済みです"
+        demo_modal:
+          title: "本機能は、現時点で未実装です。"
+          body: "利用にあたっては、Googleアカウントでログインしてください。"
+      features:
+        heading: "主な機能"
+        subheading: "技の整理からゲームプラン作成まで、これ1つでOK"
+        cards:
+          record:
+            title: "テクニックの記録"
+            body: "習った技を追加。カテゴリー（パス/スイープ/サブミッション等）で整理し、学んだ内容をノートに保存。"
+          flow:
+            title: "フローで可視化"
+            body: "技と技を線でつなぎ、フローチャートを作成。試合・スパーのシナリオ作りに。"
+          grow_from_templates:
+            title: "テンプレから成長"
+            body: "テンプレートをベースに自分専用へ。練習を重ねるほど柔術マップが育ちます。"
+      usecases:
+        heading: "こんな使い方ができます"
+        cards:
+          study_log:
+            title: "学習ログ"
+            body: "その日に習った技をすぐ追加。関連する展開をつなげて復習がラクに。"
+          game_plan:
+            title: "ゲームプラン作成"
+            body: "得意技を起点に、ガード→スイープ→パス→極めの動線を設計。"
+          pre_comp:
+            title: "大会前の仕上げ"
+            body: "狙う展開をチャートでシミュレーション。迷いを減らし、当日集中できます。"
+        steps:
+          register: "技を登録"
+          connect: "つなげてフロー化"
+          overview: "全体像を確認"
+          update: "練習で更新"
+        stats:
+          initial_techniques:
+            title: "初期の登録技"
+            value: "90+"
+            desc: "自分のペースで増やせます"
+          flow_branches:
+            title: "フロー分岐"
+            value: "無制限"
+            desc: "自由に設計"
+          devices:
+            title: "対応端末"
+            value: "PC / モバイル"
+            desc: "どこでも復習"
+      howto:
+        heading: "はじめ方"
+        cards:
+          step1:
+            title: "1. まずはテンプレから"
+            body: "用意されたテンプレートチャートをベースに、自分の得意技を追加してみましょう。"
+          step2:
+            title: "2. 自分の言葉でメモ"
+            body: "細かいコツ・注意点をノートに。練習後すぐに更新すると定着が早いです。"
+          step3:
+            title: "3. 展開をつなぐ"
+            body: "ノード同士を線でつなぎ、試合やスパーの展開をそのまま可視化しましょう。"
+          step4:
+            title: "4. 定期的に見返す"
+            body: "試合やスパー前にチャートを確認。作戦を明確にして臨むことができます。"
+      cta:
+        heading: "今すぐ、あなたの柔術マップを作ろう"
+        subheading: "登録は1分、すぐにチャート作成へ。"
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,6 +36,7 @@ ja:
       deleted: "%{item}を削除しました"
       multiple_select: "%{item}を1つ以上選択してください"
       require_login: ログインしてください
+      wrong_input: 入力に誤りがあります
   header:
     home: Home
     technique: Technique

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,6 +29,7 @@ ja:
     delete_confirm: 削除しますか？
     back: 一覧へ戻る
     start_guide: ステップガイドを開始
+    preparing: "現在準備中です！"
     flash_messages:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
@@ -67,6 +68,10 @@ ja:
     dashboard:
       show:
         title: Dashboard
+        welcome: "ようこそ、"
+        username: "%{name}さん！"
+        take_note: "本日も練習で学んだことを記録しましょう。"
+        check_howtouse: "本アプリの使い方については、以下のステップガイドをご参照ください。"
         start_guide: ステップガイドを始める
         updates: 更新情報
         technique_details: "技の一覧と練習メモを管理します。"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -51,6 +51,15 @@ ja:
       index:
         title: Technique 
         nothing_here: 表示するテクニックがありません
-        editing_panel_title: テクニック編集
+        editing_panel_title: テクニックを編集
       new: 
-        title: 新規テクニック作成
+        title: 新規テクニックを作成
+    charts:
+      show:
+        title: "Flow Chart"
+        create_nodes: 新しいフローを作る
+    nodes:
+      drawer_header:
+        editing_panel_title: ノードを編集
+        creating_panel_title: フローの開始点を作成
+

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,12 +6,27 @@ ja:
     sign_in_with: "%{provider} でログイン"
     providers:
       google: "Google"
+  form:
+    required: 必須
   helpers:
     submit:
       create: 登録
       submit: 保存
       update: 更新
+    label:
+      technique_name: テクニック名
+      note: ノート
+      category: カテゴリー
+      children_nodes: 展開先テクニック
+      root_nodes: 開始点テクニック
   defaults:
+    create: 作成
+    search: テクニックを検索
+    edit: 編集
+    show: 詳細
+    delete: 削除
+    delete_item: "%{item}を削除"
+    delete_confirm: 削除しますか？
     flash_messages:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
@@ -19,6 +34,14 @@ ja:
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
       multiple_select: "%{item}を1つ以上選択してください"
+      require_login: ログインしてください
   header:
-    login: ログイン
+    home: Home
+    technique: Technique
+    flow_chart: "Flow Chart"
+    dashboard: Dashboard
     logout: ログアウト
+  footer:
+    inquiry: お問い合わせ
+    privacy: プライバシーポリシー
+    terms: 利用規約

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cytoscape": "^3.33.0",
     "cytoscape-dagre": "^2.5.0",
     "daisyui": "^5.0.46",
+    "i18n-js": "^4.5.1",
     "intro.js": "^8.3.2",
     "tailwindcss": "^4.1.11",
     "tom-select": "^2.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,11 @@
   dependencies:
     tslib "^2.4.0"
 
+bignumber.js@*:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
 braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -577,6 +582,15 @@ graphlib@^2.1.8:
   dependencies:
     lodash "^4.17.15"
 
+i18n-js@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-4.5.1.tgz#12ea3d6333552ff75be0904ea50705f5a263d172"
+  integrity sha512-n7jojFj1WC0tztgr0I8jqTXuIlY1xNzXnC3mjKX/YjJhimdM+jXM8vOmn9d3xQFNC6qDHJ4ovhdrGXrRXLIGkA==
+  dependencies:
+    bignumber.js "*"
+    lodash "*"
+    make-plural "*"
+
 intro.js@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/intro.js/-/intro.js-8.3.2.tgz#942129bccf0490a750ab04b1db744e3bb5f000b7"
@@ -687,7 +701,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15:
+lodash@*, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -698,6 +712,11 @@ magic-string@^0.30.17:
   integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
+
+make-plural@*:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-7.4.0.tgz#fa6990dd550dea4de6b20163f74e5ed83d8a8d6d"
+  integrity sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg==
 
 micromatch@^4.0.5:
   version "4.0.8"


### PR DESCRIPTION
## refs to #47 
- 日本語でハードコーディングしていた部分について、i18n対応を行った(プライバシーポリシー除く)
- intro.jsで実装していたステップガイド文言をi18n化するにあたり、i18n-jsを利用した。
  - gem i18n-js: Rails 側の `config/locales/*.yml`を JSON に変換し、`app/javascript/locales`配下に出力するためにインストール。これにより JS から Rails の翻訳ファイルを参照できるようにした。
  - yarnで導入したi18n-js: Stimulusコントローラーで I18n.tメソッドを利用するためにインストール 。
- ユーザーが表示される言語を選択できるようにはしていないため、#47 は未クローズ。