### PR TITLE
RSpecシステムテスト(TechniqueメニューCRUD)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -27,11 +27,16 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
     ports:
       - "3000:3000"
     depends_on:
       db:
         condition: service_healthy
+  chrome:
+    image: seleniarm/standalone-chromium:latest
+    environment:
+      - TZ=Asia/Tokyo
 volumes:
   bundle_data:
   postgresql_data:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,23 +87,3 @@ RSpec.configure do |config|
   end
 end
 
-require 'capybara-screenshot/rspec'
-# どこに保存するか（CI の artifact パスと合わせる）
-Capybara.save_path = Rails.root.join("tmp", "screenshots")
-# 失敗時に自動保存（require だけで有効だが明示しておく）
-Capybara::Screenshot.autosave_on_failure = true
-# 直近テスト分だけ残す（溜まりすぎ防止）
-Capybara::Screenshot.prune_strategy = :keep_last_run
-
-OmniAuth.configure do |c|
-  c.test_mode = true
-  c.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
-    "provider" => "google_oauth2",
-    "uid" => "100000000000000000000",
-    "info" => {
-      "name" => "test employee",
-      "email" => "tester1@example.com",
-      "image" => "https://example.com"
-    }
-  })
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,15 +75,3 @@ RSpec.configure do |config|
 
   config.include LoginMacros
 end
-
-require "capybara/rspec"
-RSpec.configure do |config|
-  # デフォルトは速いrack_test（JSなし）
-  config.before(:each, type: :system) { driven_by :rack_test }
-
-  # JS が必要なテストだけ実ブラウザ（ヘッドレスChrome）
-  config.before(:each, type: :system, js: true) do
-    driven_by :selenium_chrome_headless
-  end
-end
-

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,8 +1,6 @@
 require "capybara/rspec"
 require "selenium/webdriver"
 
-Capybara.ignore_hidden_elements = false # 非表示要素もCapybaraで取得する
-
 # リモートSelenium(ローカルDocker)向けのホスト設定
 if ENV['SELENIUM_DRIVER_URL'].present?
   Capybara.server_host = "0.0.0.0" # すべてのインターフェイスにバインド

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,31 @@
+require "capybara/rspec"
+require "selenium/webdriver"
+
+Capybara.server_host = "0.0.0.0" # すべてのインターフェイスにバインド
+Capybara.server_port = 5001 # 任意の空きポート（Seleniumの4444と被らせない）
+Capybara.app_host = "http://web:#{Capybara.server_port}" # composeのservice名 'web'
+Capybara.ignore_hidden_elements = false # 非表示要素もCapybaraで取得する
+
+Capybara.register_driver :remote_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--no-sandbox')
+  options.add_argument('--headless')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--window-size=1680,1050')
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :remote,
+    url: ENV['SELENIUM_DRIVER_URL'],
+    capabilities: options
+  )
+end
+
+RSpec.configure do |config|
+  # デフォルトは速いrack_test（JSなし）
+  config.before(:each, type: :system) { driven_by :rack_test }
+  # JS が必要なテストだけ実ブラウザ（ヘッドレスChrome）
+  config.before(:each, type: :system, js: true) { driven_by :remote_chrome }
+  # テスト前にseeds.rb(presets群)を読み込む
+  config.before(:suite) { Rails.application.load_seed }
+end

--- a/spec/support/capybara_screenshot.rb
+++ b/spec/support/capybara_screenshot.rb
@@ -1,7 +1,12 @@
 require 'capybara-screenshot/rspec'
+
+# ローカルテストで使用するドライバ用のスナップショットs設定
 Capybara::Screenshot.register_driver(:remote_chrome) do |driver, path|
   driver.browser.save_screenshot(path)
 end
+
+# CIテストで使用するドライバ用のスナップショットs設定
+Capybara::Screenshot.register_driver(:selenium_chrome_headless) { |d, p| d.browser.save_screenshot(p) }
 # どこに保存するか（CI の artifact パスと合わせる）
 Capybara.save_path = Rails.root.join("tmp", "screenshots")
 # 失敗時に自動保存（require だけで有効だが明示しておく）

--- a/spec/support/capybara_screenshot.rb
+++ b/spec/support/capybara_screenshot.rb
@@ -1,0 +1,10 @@
+require 'capybara-screenshot/rspec'
+Capybara::Screenshot.register_driver(:remote_chrome) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+# どこに保存するか（CI の artifact パスと合わせる）
+Capybara.save_path = Rails.root.join("tmp", "screenshots")
+# 失敗時に自動保存（require だけで有効だが明示しておく）
+Capybara::Screenshot.autosave_on_failure = true
+# 直近テスト分だけ残す（溜まりすぎ防止）
+Capybara::Screenshot.prune_strategy = :keep_last_run

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -4,7 +4,18 @@ module LoginMacros
     Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
 
     visit root_path
-    click_on "Google でログイン", match: :first
+
+    tp_count = TechniquePreset.count
+    np_count = NodePreset.count
+
+    expect {
+      click_on "Google でログイン", match: :first
+    }.to change(User, :count).by(1)
     expect(page).to have_current_path(mypage_root_path(locale: I18n.locale))
+
+    new_user = User.find_by!(email: "tester1@example.com")
+    expect(new_user.techniques.count).to eq(tp_count)
+    expect(new_user.nodes.count).to eq(np_count)
+    expect(new_user.charts.count).to eq(1)
   end
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -5,13 +5,17 @@ module LoginMacros
 
     visit root_path
 
-    tp_count = TechniquePreset.count
-    np_count = NodePreset.count
-
+    # ログイン後、ユーザー数が1増加することを確認
     expect {
       click_on "Google でログイン", match: :first
     }.to change(User, :count).by(1)
+
+    # ログイン後、ダッシュボード画面に遷移することを確認
     expect(page).to have_current_path(mypage_root_path(locale: I18n.locale))
+
+    # presetsがユーザー所有のテクニック・ノード・チャートにコピーされていることを確認
+    tp_count = TechniquePreset.count
+    np_count = NodePreset.count
 
     new_user = User.find_by!(email: "tester1@example.com")
     expect(new_user.techniques.count).to eq(tp_count)

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,12 @@
+OmniAuth.configure do |c|
+  c.test_mode = true
+  c.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+    "provider" => "google_oauth2",
+    "uid" => "100000000000000000000",
+    "info" => {
+      "name" => "test employee",
+      "email" => "tester1@example.com",
+      "image" => "https://example.com"
+    }
+  })
+end

--- a/spec/system/logins_spec.rb
+++ b/spec/system/logins_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "Logins", type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   describe "ログイン・ログアウト" do
     it "ログインできる" do
       omniauth_login

--- a/spec/system/techniques_spec.rb
+++ b/spec/system/techniques_spec.rb
@@ -2,8 +2,55 @@ require 'rails_helper'
 
 RSpec.describe "Techniques", type: :system do
   before do
-    driven_by(:rack_test)
+    omniauth_login
   end
 
-  pending "add some scenarios (or delete) #{__FILE__}"
+  let(:user) { User.find_by(email: "tester1@example.com") }
+
+  # pending "add some scenarios (or delete) #{__FILE__}"
+
+  describe "indexアクション" do
+    it "ダッシュボードからテクニック画面に遷移できる" do
+      click_on "Technique", match: :first
+      expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
+    end
+
+    context "登録されたテクニックがない場合" do
+      it "表示するテクニックがない旨が表示される" do
+        visit mypage_techniques_path
+        expect(page).to have_content(I18n.t("mypage.techniques.index.nothing_here"))
+      end
+    end
+
+    context "登録されているテクニックがある場合" do
+      let!(:technique) do
+        user.techniques.create! do |t|
+          t.set_name_for("test1")
+        end
+      end
+
+      it "プリセットのテクニックが確認できる" do
+        visit mypage_techniques_path
+        expect(page).to have_content("test1")
+      end
+    end
+  end
+
+  describe "showアクション" do
+  end
+
+  describe "newアクション" do
+  end
+
+  describe "editアクション" do
+  end
+
+  describe "createアクション" do
+  end
+
+  describe "updateアクション" do
+  end
+
+  describe "destroyアクション" do
+  end
 end

--- a/spec/system/techniques_spec.rb
+++ b/spec/system/techniques_spec.rb
@@ -60,6 +60,22 @@ RSpec.describe "Techniques", type: :system do
   end
 
   describe "editアクション" do
+    let!(:technique) do
+      user.techniques.create! do |t|
+        t.set_name_for("test1")
+      end
+    end
+
+    it "編集フォームが表示される", :js do
+      visit mypage_techniques_path(locale: I18n.locale)
+      expect(page).to have_css('a[data-turbo-frame="technique-drawer"]')
+      find('a[data-turbo-frame="technique-drawer"]', match: :first).click
+      expect(page).to have_field(I18n.t("helpers.label.technique_name"), with: "test1")
+      expect(page).to have_field(I18n.t("helpers.label.note"))
+      expect(page).to have_field(I18n.t("helpers.label.category"))
+      expect(page).to have_button(I18n.t("helpers.submit.update"))
+      expect(page).to have_link(I18n.t("defaults.delete"))
+    end
   end
 
   describe "createアクション" do

--- a/spec/system/techniques_spec.rb
+++ b/spec/system/techniques_spec.rb
@@ -202,5 +202,28 @@ RSpec.describe "Techniques", type: :system do
   end
 
   describe "destroyアクション" do
+    before do
+      user.techniques.create! do |t|
+        t.set_name_for("test1")
+      end
+    end
+
+    # モーダルが出てくるので要js
+    it "テクニックを削除できる", :js do
+      visit mypage_techniques_path(locale: I18n.locale)
+      expect(page).to have_css('a[data-turbo-frame="technique-drawer"]')
+      find('a[data-turbo-frame="technique-drawer"]', match: :first).click
+
+      expect {
+        accept_confirm(I18n.t("defaults.delete_confirm")) do
+          click_link(I18n.t("defaults.delete"))
+        end
+
+        expect(page).to have_content(I18n.t("defaults.flash_messages.deleted", item: Technique.model_name.human))
+      }.to change(user.techniques, :count).by(-1)
+
+      expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
+      expect(page).not_to have_content("test1")
+    end
   end
 end

--- a/spec/system/techniques_spec.rb
+++ b/spec/system/techniques_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Techniques", type: :system do
   # pending "add some scenarios (or delete) #{__FILE__}"
 
   describe "indexアクション" do
-    it "ダッシュボードからテクニック画面に遷移できる" do
+    it "ダッシュボードにあるテクニック画面へのリンクが機能する" do
       click_on "Technique", match: :first
       expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
     end
@@ -30,16 +30,32 @@ RSpec.describe "Techniques", type: :system do
       end
 
       it "プリセットのテクニックが確認できる" do
-        visit mypage_techniques_path
+        visit mypage_techniques_path(locale: I18n.locale)
         expect(page).to have_content("test1")
       end
     end
-  end
 
-  describe "showアクション" do
+    it "新規作成ページへのリンクが機能する" do
+      visit mypage_techniques_path
+      click_link(I18n.t("defaults.create"))
+      expect(page).to have_current_path(new_mypage_technique_path(locale: I18n.locale))
+    end
   end
 
   describe "newアクション" do
+    it "新規作成フォームが表示される" do
+      visit new_mypage_technique_path(locale: I18n.locale)
+      expect(page).to have_field(I18n.t("helpers.label.technique_name"))
+      expect(page).to have_field(I18n.t("helpers.label.note"))
+      expect(page).to have_field(I18n.t("helpers.label.category"))
+      expect(page).to have_button(I18n.t("helpers.submit.create"))
+    end
+
+    it "一覧ページへ戻るリンクが機能する" do
+      visit new_mypage_technique_path(locale: I18n.locale)
+      click_link(I18n.t("defaults.back"))
+      expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
+    end
   end
 
   describe "editアクション" do

--- a/spec/system/techniques_spec.rb
+++ b/spec/system/techniques_spec.rb
@@ -15,28 +15,29 @@ RSpec.describe "Techniques", type: :system do
       expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
     end
 
-    context "登録されたテクニックがない場合" do
+    it "プリセットのテクニックが確認できる" do
+      visit mypage_techniques_path(locale: I18n.locale)
+      expect(page).to have_content("マウント")
+    end
+
+    context "登録されたテクニックがない(プリセットを含めテクニックを全削除した)場合" do
+      before do
+        Edge.destroy_all
+        user.charts.find_each do |chart|
+          # chart.edges.delete_all #まだリレーションを作成していないためコメントアウト
+          chart.nodes.delete_all
+        end
+        user.techniques.delete_all
+      end
+
       it "表示するテクニックがない旨が表示される" do
-        visit mypage_techniques_path
+        visit mypage_techniques_path(locale: I18n.locale)
         expect(page).to have_content(I18n.t("mypage.techniques.index.nothing_here"))
       end
     end
 
-    context "登録されているテクニックがある場合" do
-      let!(:technique) do
-        user.techniques.create! do |t|
-          t.set_name_for("test1")
-        end
-      end
-
-      it "プリセットのテクニックが確認できる" do
-        visit mypage_techniques_path(locale: I18n.locale)
-        expect(page).to have_content("test1")
-      end
-    end
-
     it "新規作成ページへのリンクが機能する" do
-      visit mypage_techniques_path
+      visit mypage_techniques_path(locale: I18n.locale)
       click_link(I18n.t("defaults.create"))
       expect(page).to have_current_path(new_mypage_technique_path(locale: I18n.locale))
     end

--- a/spec/system/techniques_spec.rb
+++ b/spec/system/techniques_spec.rb
@@ -79,6 +79,57 @@ RSpec.describe "Techniques", type: :system do
   end
 
   describe "createアクション" do
+    context "有効なデータの場合" do
+      it "テクニックが作成できる" do
+        visit new_mypage_technique_path(locale: I18n.locale)
+        fill_in I18n.t("helpers.label.technique_name"), with: "test1"
+        fill_in I18n.t("helpers.label.note"), with: "test note!"
+        select I18n.t("enums.category.submission"), from: I18n.t("helpers.label.category")
+        expect {
+          click_button(I18n.t("helpers.submit.create"))
+        }.to change(user.techniques, :count).by(1)
+        expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
+        expect(page).to have_content("test1")
+        expect(page).to have_content("test note!")
+        expect(page).to have_content(I18n.t("defaults.flash_messages.created", item: Technique.model_name.human))
+      end
+    end
+
+    context "テクニック名が空の場合" do
+      it "テクニックの作成に失敗する" do
+        visit new_mypage_technique_path(locale: I18n.locale)
+        fill_in I18n.t("helpers.label.note"), with: "test note!"
+        select I18n.t("enums.category.submission"), from: I18n.t("helpers.label.category")
+        expect {
+          click_button(I18n.t("helpers.submit.create"))
+        }.to change(user.techniques, :count).by(0)
+        expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
+        expect(page).to have_content(I18n.t("defaults.flash_messages.not_created", item: Technique.model_name.human))
+        # #{Technique.human_attribute_name(:name_ja)} = I18n.t("activerecord.attributes.technique.name_ja")
+        expect(page).to have_content("#{Technique.human_attribute_name(:name_ja)}#{I18n.t('errors.messages.blank')}")
+      end
+    end
+
+    context "テクニック名が既存データと重複する場合" do
+        let!(:technique) do
+          user.techniques.create! do |t|
+            t.set_name_for("test1")
+          end
+        end
+
+      it "テクニックの作成の失敗する" do
+        visit new_mypage_technique_path(locale: I18n.locale)
+        fill_in I18n.t("helpers.label.technique_name"), with: "test1"
+        fill_in I18n.t("helpers.label.note"), with: "test note!"
+        select I18n.t("enums.category.submission"), from: I18n.t("helpers.label.category")
+        expect {
+          click_button(I18n.t("helpers.submit.create"))
+        }.to change(user.techniques, :count).by(0)
+        expect(page).to have_current_path(mypage_techniques_path(locale: I18n.locale))
+        expect(page).to have_content(I18n.t("defaults.flash_messages.not_created", item: Technique.model_name.human))
+        expect(page).to have_content("#{Technique.human_attribute_name(:name_ja)}#{I18n.t('errors.messages.taken')}")
+      end
+    end
   end
 
   describe "updateアクション" do


### PR DESCRIPTION
## close #137 
### 概要
- Technique関連のCRUDを確認するRSpecテストを作成しました。
- JavaScriptを伴う処理（例：テクニック削除時の確認ダイアログでOK操作）がテスト内で実行できるよう、`spec/rails_helper.rb`や`compose.yml`にCapybara ドライバ関連の設定を追記しました。
### issueに書いていないが、やったこと
- JavaScriptを伴う処理がテスト内で実行できるよう、`spec/rails_helper.rb`や`compose.yml`にCapybara ドライバ関連の設定を追記
- テスト前にseeds.rbを読み込み、TechniquePresetsとNodePresetsが読み込まれるようにした
### issueに書いたが、やらなかったこと
- ロケール関連のテスト（#140 でまとめて実施する予定）
  - ユーザー独自のテクニックは、テクニック名を更新した際に、もう片方のロケールに変更後の名前が反映される（ロケール問わず表示されるテクニック名が同じである）こと。
  - テクニックプリセットからコピーされたテクニック（technique_preset_idを持つテクニック）は、テクニック名を更新しても、もう片方のロケールに変更後の名前が反映されない（ロケールを切り替えた時に英日で違うテクニック名が表示される）こと。
