### PR TITLE
chore: RSpecモデルテスト(ChartPresetモデル)作成

### DIFF
--- a/app/models/chart_preset.rb
+++ b/app/models/chart_preset.rb
@@ -1,5 +1,7 @@
 class ChartPreset < ApplicationRecord
-  # ユーザー所有のチャートである可能性が高いため、dependent: :destroyは行わない
+  # ユーザー所有のチャートが削除される可能性が高いため、dependent: :destroyは行わない
   has_many :charts
   has_many :node_presets, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/chart_preset.rb
+++ b/app/models/chart_preset.rb
@@ -1,6 +1,6 @@
 class ChartPreset < ApplicationRecord
   # ユーザー所有のチャートが削除される可能性が高いため、dependent: :destroyは行わない
-  has_many :charts
+  has_many :charts, dependent: :restrict_with_exception
   has_many :node_presets, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/technique_preset.rb
+++ b/app/models/technique_preset.rb
@@ -1,6 +1,7 @@
 class TechniquePreset < ApplicationRecord
-  has_many :techniques
-  has_many :node_presets
+  # ユーザー所有のテクニックが削除される可能性が高いため、dependent: :destroyは行わない
+  has_many :techniques, dependent: :restrict_with_exception
+  has_many :node_presets, dependent: :destroy
 
   validates :name_ja, presence: true, uniqueness: true
   validates :name_en, presence: true, uniqueness: true

--- a/spec/factories/node_presets.rb
+++ b/spec/factories/node_presets.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :node_preset do
+    association :chart_preset
+    association :technique_preset
+    ancestry { "/" }
+  end
+end

--- a/spec/models/chart_preset_spec.rb
+++ b/spec/models/chart_preset_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ChartPreset, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/chart_preset_spec.rb
+++ b/spec/models/chart_preset_spec.rb
@@ -1,5 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe ChartPreset, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    it "必須項目が揃っていれば有効" do
+      tp = create(:chart_preset)
+      expect(tp).to be_valid
+      expect(tp.errors).to be_empty
+    end
+
+    it "name が空だと無効" do
+      tp = build(:chart_preset, name: "")
+      expect(tp).to be_invalid
+      expect(tp.errors).to be_of_kind(:name, :blank)
+    end
+
+    it "name は一意" do
+      dup_name = "test1"
+      create(:chart_preset, name: dup_name)
+      dup = build(:chart_preset, name: dup_name)
+
+      expect(dup).to be_invalid
+      expect(dup.errors).to be_of_kind(:name, :taken)
+    end
+  end
+
+  describe "リレーション" do
+    it "関連チャートがある場合は削除できない" do
+      cp = create(:chart_preset)
+      create_list(:chart, 2, chart_preset: cp)
+
+      expect {
+        cp.destroy
+      }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    it "削除時に関連プリセットノードが消える" do
+      cp = create(:chart_preset)
+      create_list(:node_preset, 2, chart_preset: cp)
+
+      expect {
+        cp.destroy
+      }.to change { NodePreset.where(chart_preset_id: cp.id).count }.from(2).to(0)
+    end
+  end
 end

--- a/spec/models/chart_spec.rb
+++ b/spec/models/chart_spec.rb
@@ -3,28 +3,8 @@ require 'rails_helper'
 RSpec.describe Chart, type: :model do
   let(:user) { create(:user) }
 
-  describe "関連" do
-    it "ユーザーに必須で属する" do
-      c = build(:chart, user: nil, name: "test1")
-      expect(c).to be_invalid
-      expect(c.errors).to be_of_kind(:user, :blank)
-    end
-
-    it "chart_preset は任意" do
-      c = build(:chart, chart_preset: nil, user:, name: "test1")
-      expect(c).to be_valid
-      expect(c.errors).to be_empty
-    end
-
-    it "削除時に関連ノードが消える" do
-      c = create(:chart, user:)
-      create_list(:node, 2, chart: c)
-      expect { c.destroy }.to change { Node.where(chart_id: c.id).count }.from(2).to(0)
-    end
-  end
-
   describe "バリデーション" do
-    it "バリデーションをクリアするデータであれば有効" do
+    it "必須項目が揃っていれば有効" do
       c = build(:chart)
       expect(c).to be_valid
       expect(c.errors).to be_empty
@@ -51,6 +31,26 @@ RSpec.describe Chart, type: :model do
       dup = build(:chart, user: other_user, name: dup_name)
       expect(dup).to be_valid
       expect(dup.errors).to be_empty
+    end
+  end
+
+  describe "リレーション" do
+    it "ユーザーに必須で属する" do
+      c = build(:chart, user: nil, name: "test1")
+      expect(c).to be_invalid
+      expect(c.errors).to be_of_kind(:user, :blank)
+    end
+
+    it "chart_preset は任意" do
+      c = build(:chart, chart_preset: nil, user:, name: "test1")
+      expect(c).to be_valid
+      expect(c.errors).to be_empty
+    end
+
+    it "削除時に関連ノードが消える" do
+      c = create(:chart, user:)
+      create_list(:node, 2, chart: c)
+      expect { c.destroy }.to change { Node.where(chart_id: c.id).count }.from(2).to(0)
     end
   end
 end

--- a/spec/models/technique_preset_spec.rb
+++ b/spec/models/technique_preset_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe TechniquePreset, type: :model do
     it "必須項目が揃っていれば有効" do
       tp = create(:technique_preset, name_ja: "テスト1", name_en: "test1", category: :control)
       expect(tp).to be_valid
-      expect(tp.save).to be true
       expect(tp.errors).to be_empty
     end
 
@@ -43,6 +42,27 @@ RSpec.describe TechniquePreset, type: :model do
         expect(tp.errors).to be_empty
     end
   end
+
+  describe "リレーション" do
+    it "関連テクニックがある場合は削除できない" do
+      tp = create(:technique_preset)
+      create(:technique, name_ja: "テスト1", name_en: "test1", technique_preset: tp)
+
+      expect {
+        tp.destroy
+      }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    it "削除時に関連プリセットノードが消える" do
+      tp = create(:technique_preset)
+      create_list(:node_preset, 2, technique_preset: tp)
+
+      expect {
+        tp.destroy
+      }.to change { NodePreset.where(technique_preset_id: tp.id).count }.from(2).to(0)
+    end
+  end
+
 
   describe "enum :category" do
     it "定義されたキーを受け付ける" do

--- a/spec/models/technique_spec.rb
+++ b/spec/models/technique_spec.rb
@@ -3,28 +3,8 @@ require 'rails_helper'
 RSpec.describe Technique, type: :model do
   let(:user) { create(:user) }
 
-  describe "関連" do
-    it "ユーザーに必須で属する" do
-      t = build(:technique, user: nil, name_ja: "テスト1", name_en: "test1")
-      expect(t).to be_invalid
-      expect(t.errors).to be_of_kind(:user, :blank)
-    end
-
-    it "technique_preset は任意" do
-      t = build(:technique, :no_preset, user:)
-      expect(t).to be_valid
-      expect(t.errors).to be_empty
-    end
-
-    it "削除時に関連ノードが消える" do
-      t = create(:technique, user:)
-      create_list(:node, 2, technique: t)
-      expect { t.destroy }.to change { Node.where(technique_id: t.id).count }.from(2).to(0)
-    end
-  end
-
   describe "バリデーション" do
-    it "バリデーションをクリアするデータであれば有効" do
+    it "必須項目が揃っていれば有効" do
       t = build(:technique)
       expect(t).to be_valid
       expect(t.errors).to be_empty
@@ -73,6 +53,27 @@ RSpec.describe Technique, type: :model do
       expect(dup.errors).to be_empty
     end
   end
+
+  describe "リレーション" do
+    it "ユーザーに必須で属する" do
+      t = build(:technique, user: nil, name_ja: "テスト1", name_en: "test1")
+      expect(t).to be_invalid
+      expect(t.errors).to be_of_kind(:user, :blank)
+    end
+
+    it "technique_preset は任意" do
+      t = build(:technique, :no_preset, user:)
+      expect(t).to be_valid
+      expect(t.errors).to be_empty
+    end
+
+    it "削除時に関連ノードが消える" do
+      t = create(:technique, user:)
+      create_list(:node, 2, technique: t)
+      expect { t.destroy }.to change { Node.where(technique_id: t.id).count }.from(2).to(0)
+    end
+  end
+
 
   describe "enum :category" do
     it "定義されたキーを受け付ける" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe "バリデーション" do
+    it "必須項目が揃っていれば有効" do
+      u = build(:user)
+      expect(u).to be_valid
+      expect(u.errors).to be_empty
+    end
+
     it "provider/uid/name/email が必須" do
       user = User.new
       expect(user).to be_invalid


### PR DESCRIPTION
## close #133
### 概要
ChartPresetモデルに関するRSpecテストを作成しました。
### issueに書かなかったが、実装したもの
- ChartPresetモデル、TechnqiuePresetモデル削除時の挙動に関する記述を追加（[fix: has_many関連を持ったオブジェクトの削除時挙動を見直し](https://github.com/m-deura/bjj_flow_tracker/commit/4d65f77e0b27a268f72c9d5b855dfafa39d65c8b)）
  - ChartPreset / TechnqiuePresetともに、関連するチャート / テクニックが存在する場合（すでに当該プリセットをコピーしたユーザーが作成されている場合）は、プリセット側を削除できない（エラーが発生する）処理となるよう、モデルファイルの記述を修正しました。
- NodePresetデータを生成するFactoryBotファイルを追加（[add: FactoryBotによるテスト用データ生成ファイルを追加](https://github.com/m-deura/bjj_flow_tracker/commit/58e2df1485900c159fd54b56c7d72c19066c7f45)）
- モデルファイル全体のリファクタリング（テストケース文言の修正や実行順序の入れ替え）
### issue に書いたが、実装しなかったもの
なし