### PR TITLE
chore: RSpecモデルテスト(Nodeモデル)を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
       chrome:
-        image: selenium/standalone-chrome:latest
+        image: selenium/standalone-chrome:140.0
         env:
           TZ: Asia/Tokyo
         ports: 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -1,5 +1,5 @@
 class Node < ApplicationRecord
-  belongs_to :chart, optional: true
-  belongs_to :technique, optional: true
+  belongs_to :chart
+  belongs_to :technique
   has_ancestry ancestry_format: :materialized_path2
 end

--- a/compose.yml
+++ b/compose.yml
@@ -34,7 +34,7 @@ services:
       db:
         condition: service_healthy
   chrome:
-    image: seleniarm/standalone-chromium:latest
+    image: seleniarm/standalone-chromium:140.0
     environment:
       - TZ=Asia/Tokyo
 volumes:

--- a/spec/factories/nodes.rb
+++ b/spec/factories/nodes.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :node do
     association :chart
     association :technique
+    ancestry { "/" }
   end
 end

--- a/spec/models/chart_spec.rb
+++ b/spec/models/chart_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Chart, type: :model do
   end
 
   describe "リレーション" do
-    it "ユーザーに必須で属する" do
+    it "user が必須" do
       c = build(:chart, user: nil, name: "test1")
       expect(c).to be_invalid
       expect(c.errors).to be_of_kind(:user, :blank)

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Node, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Node, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    it "必須項目が揃っていれば有効" do
+      t = build(:node)
+      expect(t).to be_valid
+      expect(t.errors).to be_empty
+    end
+  end
+
+  describe "リレーション" do
+    it "chart_preset が必須" do
+      t = build(:node, chart: nil)
+      expect(t).to be_invalid
+      expect(t.errors).to be_of_kind(:chart, :blank)
+    end
+
+    it "technique_preset が必須" do
+      t = build(:node, technique: nil)
+      expect(t).to be_invalid
+      expect(t.errors).to be_of_kind(:technique, :blank)
+    end
+  end
 end

--- a/spec/models/technique_spec.rb
+++ b/spec/models/technique_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Technique, type: :model do
   end
 
   describe "リレーション" do
-    it "ユーザーに必須で属する" do
+    it "user が必須" do
       t = build(:technique, user: nil, name_ja: "テスト1", name_en: "test1")
       expect(t).to be_invalid
       expect(t.errors).to be_of_kind(:user, :blank)


### PR DESCRIPTION
## close #134
### 概要
Nodeモデルに関するRSpecテストを作成しました。
### issueに書かなかったが、実装したもの
- [fix: Seleniumイメージのメジャーバージョンを固定](https://github.com/m-deura/bjj_flow_tracker/commit/875f6b0bdaccb9022377927f4e82804a58a71d52)
  - 理由：CI環境でのRSpecにて、Chrome と ChromeDriver のメジャーバージョン差異が原因のエラーが発生していたため。）※エラーは下記の通り。
  ```
  session not created: This version of ChromeDriver only supports Chrome version 141
  Current browser version is 140.0.7339.185 with binary path /usr/bin/google-chrome
  ```
- [update: chart とtechnique を必須カラムに変更](https://github.com/m-deura/bjj_flow_tracker/commit/cfd9426b80a313ea3cf0b81672967e35d31e2da3)
  - 今回対応したのはモデルファイルのみ。マイグレーションファイルにおける`null: false`制約追加は、#174 にて対応する。
### issue に書いたが、実装しなかったもの
- テストケース "ancestry が nil の場合、ノード作成に失敗する"（理由：ancestry は #174 にて削除予定であるため）