### PR TITLE
chore: Enhance CI workflow with chromedriver inspection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,22 @@ jobs:
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+      - name: Inspect Chrome/Driver on runner
+        run: |
+          set -eux
+          which -a chromedriver || true
+          ls -l $(which chromedriver) || true
+
+      - name: Remove the chromedriver that would be used
+        run: |
+          set -eux
+          if command -v chromedriver >/dev/null 2>&1; then
+            TARGET="$(command -v chromedriver)"
+            echo "Removing $TARGET"
+            sudo rm -f "$TARGET" || true
+          fi
+          which -a chromedriver || echo "no chromedriver in PATH (good)"
+    
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client
 
@@ -76,7 +92,6 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      # jsbundling-rails / cssbundling-rails を使うなら Node とビルドが必要
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'


### PR DESCRIPTION
# やったこと
Added steps to inspect and remove chromedriver in CI workflow.

# 理由/目的
Dependabot の CI環境 RSpec 実行時に以下エラーが発生するため。
使用するのはリモートの Chrome であるため、エラーの内容通りローカルの Chrome は削除しても問題ないと判断した。
```
[:selenium_manager] The chromedriver version (141.0.7390.78) detected in PATH at /opt/hostedtoolcache/setup-chrome/chromedriver/stable/x64/chromedriver might not be compatible with the detected chrome version (140.0.7339.207); currently, chromedriver 140.0.7339.207 is recommended for chrome 140.*, so it is advised to delete the driver in PATH and retry
```
