### PR TITLE
Revert "chore: Enhance CI workflow with chromedriver inspection"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,22 +64,6 @@ jobs:
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - name: Inspect Chrome/Driver on runner
-        run: |
-          set -eux
-          which -a chromedriver || true
-          ls -l $(which chromedriver) || true
-
-      - name: Remove the chromedriver that would be used
-        run: |
-          set -eux
-          if command -v chromedriver >/dev/null 2>&1; then
-            TARGET="$(command -v chromedriver)"
-            echo "Removing $TARGET"
-            sudo rm -f "$TARGET" || true
-          fi
-          which -a chromedriver || echo "no chromedriver in PATH (good)"
-    
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client
 
@@ -92,6 +76,7 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      # jsbundling-rails / cssbundling-rails を使うなら Node とビルドが必要
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'


### PR DESCRIPTION
# Reverts m-deura/bjj_flow_tracker#211
Dependabot の CI 環境で RSpec のみが失敗していたため、エラーメッセージに従ってローカル ChromeDriver を削除する対応を行っていた。
しかし後に、根本原因は 使用されていた .github/workflows/ci.yml が古いままだったことに気づいた。

そのため、該当の Dependabot PR（#182）で
`@dependabot rebase` とコメントし、PRブランチを最新の base ブランチ（main）上にリベースして再実行したところ、RSpec テストが正常に通過した。

以上の経緯から、本変更（ChromeDriver削除対応）は不要と判断し、Revert して様子を見ることにした。